### PR TITLE
タブ画面の名称を削除などなどの改善実装

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -13,7 +13,7 @@
   "settingsCheckVersionDialogTitle": "Update Information",
   "settingsCheckVersionDialogText1": "A newer version is available.",
   "settingsCheckVersionDialogText2": "Please update to the latest version.",
-  "settingsDeveloper": "Developer",
+  "settingsDeveloper": "Twitter",
   "settingsGithub": "Github",
   "settingsReview": "Support with a Review",
   "settingsShareApp": "Share this app",

--- a/assets/l10n/app_ja.arb
+++ b/assets/l10n/app_ja.arb
@@ -13,7 +13,7 @@
   "settingsCheckVersionDialogTitle": "更新情報",
   "settingsCheckVersionDialogText1": "新しいバージョンがご利用いただけます。",
   "settingsCheckVersionDialogText2": "最新版にアップデートしてご利用ください。",
-  "settingsDeveloper": "開発者",
+  "settingsDeveloper": "公式Twitter",
   "settingsGithub": "Github",
   "settingsReview": "レビューする",
   "settingsLicense": "ライセンス",

--- a/lib/gen/l10n/l10n.dart
+++ b/lib/gen/l10n/l10n.dart
@@ -183,7 +183,7 @@ abstract class L10n {
   /// No description provided for @settingsDeveloper.
   ///
   /// In ja, this message translates to:
-  /// **'開発者'**
+  /// **'公式Twitter'**
   String get settingsDeveloper;
 
   /// No description provided for @settingsGithub.

--- a/lib/gen/l10n/l10n_en.dart
+++ b/lib/gen/l10n/l10n_en.dart
@@ -51,7 +51,7 @@ class L10nEn extends L10n {
   String get settingsCheckVersionDialogText2 => 'Please update to the latest version.';
 
   @override
-  String get settingsDeveloper => 'Developer';
+  String get settingsDeveloper => 'Twitter';
 
   @override
   String get settingsGithub => 'Github';

--- a/lib/gen/l10n/l10n_ja.dart
+++ b/lib/gen/l10n/l10n_ja.dart
@@ -51,7 +51,7 @@ class L10nJa extends L10n {
   String get settingsCheckVersionDialogText2 => '最新版にアップデートしてご利用ください。';
 
   @override
-  String get settingsDeveloper => '開発者';
+  String get settingsDeveloper => '公式Twitter';
 
   @override
   String get settingsGithub => 'Github';

--- a/lib/ui/screen/setting/setting_screen.dart
+++ b/lib/ui/screen/setting/setting_screen.dart
@@ -15,8 +15,6 @@ import 'package:food_gram_app/utils/snack_bar_manager.dart';
 import 'package:food_gram_app/utils/url_launch.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
-import 'package:in_app_review/in_app_review.dart';
-import 'package:new_version_plus/new_version_plus.dart';
 import 'package:share_plus/share_plus.dart';
 
 class SettingScreen extends ConsumerStatefulWidget {
@@ -90,31 +88,18 @@ class SettingScreenState extends ConsumerState<SettingScreen> {
                       icon: Icons.rate_review_outlined,
                       color: Colors.indigoAccent,
                       title: l10n.settingsReview,
-                      onTap: () async {
-                        final inAppReview = InAppReview.instance;
-                        if (await inAppReview.isAvailable()) {
-                          await inAppReview.requestReview();
-                        }
+                      onTap: () {
+                        ref.read(settingViewModelProvider().notifier).review();
                       },
                     ),
                     AppSettingTile(
                       icon: Icons.system_update,
                       color: Colors.deepPurpleAccent,
                       title: l10n.settingsCheckVersion,
-                      onTap: () async {
-                        final newVersion = NewVersionPlus();
-                        final status = await newVersion.getVersionStatus();
-                        if (status != null) {
-                          newVersion.showUpdateDialog(
-                            context: context,
-                            versionStatus: status,
-                            dialogTitle: l10n.settingsCheckVersionDialogTitle,
-                            dialogText:
-                                '${l10n.settingsCheckVersionDialogText1}\n'
-                                '${l10n.settingsCheckVersionDialogText2}',
-                            launchModeVersion: LaunchModeVersion.external,
-                          );
-                        }
+                      onTap: () {
+                        ref
+                            .read(settingViewModelProvider().notifier)
+                            .checkNewVersion(context);
                       },
                     ),
                     AppSettingTile(

--- a/lib/ui/screen/setting/setting_screen.dart
+++ b/lib/ui/screen/setting/setting_screen.dart
@@ -47,10 +47,7 @@ class SettingScreenState extends ConsumerState<SettingScreen> {
                       color: Colors.blue,
                       title: l10n.settingsDeveloper,
                       onTap: () {
-                        LaunchUrl().openSNSUrl(
-                          'twitter://user?screen_name=isekiryu',
-                          'https://twitter.com/isekiryu',
-                        );
+                        LaunchUrl().openSNSUrl('https://x.com/FoodGram_dev');
                       },
                     ),
                     AppSettingTile(

--- a/lib/ui/screen/setting/setting_view_model.dart
+++ b/lib/ui/screen/setting/setting_view_model.dart
@@ -2,9 +2,13 @@ import 'dart:io';
 
 import 'package:battery_info/battery_info_plugin.dart';
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/material.dart';
 import 'package:food_gram_app/core/data/supabase/auth_service.dart';
+import 'package:food_gram_app/gen/l10n/l10n.dart';
 import 'package:food_gram_app/ui/screen/setting/setting_state.dart';
 import 'package:food_gram_app/utils/provider/loading.dart';
+import 'package:in_app_review/in_app_review.dart';
+import 'package:new_version_plus/new_version_plus.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -45,6 +49,44 @@ class SettingViewModel extends _$SettingViewModel {
     state = state.copyWith(
       version: packageInfo.version,
     );
+  }
+
+  Future<void> review() async {
+    loading.state = true;
+    final inAppReview = InAppReview.instance;
+    if (await inAppReview.isAvailable()) {
+      loading.state = false;
+      await inAppReview.requestReview();
+    }
+  }
+
+  Future<void> checkNewVersion(BuildContext context) async {
+    loading.state = true;
+    final l10n = L10n.of(context);
+    final newVersion = NewVersionPlus();
+    final status = await newVersion.getVersionStatus();
+    final packageInfo = await PackageInfo.fromPlatform();
+    final storeVersion =
+        double.parse(status!.storeVersion.replaceAll('.', '')) / 100;
+    final appVersion =
+        double.parse(packageInfo.version.replaceAll('.', '')) / 100;
+    loading.state = false;
+    if (storeVersion > appVersion) {
+      newVersion.showUpdateDialog(
+        context: context,
+        versionStatus: status,
+        dialogTitle: l10n.settingsCheckVersionDialogTitle,
+        dialogText: '${l10n.settingsCheckVersionDialogText1}\n'
+            '${l10n.settingsCheckVersionDialogText2}',
+        launchModeVersion: LaunchModeVersion.external,
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('This App is new version👍'),
+        ),
+      );
+    }
   }
 
   Future<bool> signOut() async {

--- a/lib/ui/screen/tab/tab_screen.dart
+++ b/lib/ui/screen/tab/tab_screen.dart
@@ -14,52 +14,67 @@ class TabScreen extends ConsumerWidget {
     final l10n = L10n.of(context);
     return Scaffold(
       body: controller.pageList[state.selectedIndex],
-      bottomNavigationBar: Theme(
-        data: Theme.of(context).copyWith(
-          splashColor: Colors.transparent,
-          highlightColor: Colors.transparent,
-        ),
-        child: BottomNavigationBar(
-          currentIndex: state.selectedIndex,
-          onTap: controller.onTap,
-          items: <BottomNavigationBarItem>[
-            BottomNavigationBarItem(
-              icon: Icon(
-                Icons.fastfood_outlined,
-                semanticLabel: 'timelineIcon',
+      bottomNavigationBar: SizedBox(
+        height: 80,
+        child: Theme(
+          data: Theme.of(context).copyWith(
+            splashColor: Colors.transparent,
+            highlightColor: Colors.transparent,
+          ),
+          child: BottomNavigationBar(
+            currentIndex: state.selectedIndex,
+            onTap: controller.onTap,
+            items: <BottomNavigationBarItem>[
+              BottomNavigationBarItem(
+                icon: Padding(
+                  padding: const EdgeInsets.only(top: 18),
+                  child: Icon(
+                    Icons.fastfood_outlined,
+                    semanticLabel: 'timelineIcon',
+                  ),
+                ),
+                label: '',
               ),
-              label: l10n.tabHome,
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(
-                CupertinoIcons.map,
-                semanticLabel: 'mapIcon',
+              BottomNavigationBarItem(
+                icon: Padding(
+                  padding: const EdgeInsets.only(top: 18),
+                  child: Icon(
+                    CupertinoIcons.map,
+                    semanticLabel: 'mapIcon',
+                  ),
+                ),
+                label: '',
               ),
-              label: l10n.tabMap,
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(
-                CupertinoIcons.profile_circled,
-                semanticLabel: 'profileIcon',
+              BottomNavigationBarItem(
+                icon: Padding(
+                  padding: const EdgeInsets.only(top: 18),
+                  child: Icon(
+                    CupertinoIcons.profile_circled,
+                    semanticLabel: 'profileIcon',
+                  ),
+                ),
+                label: '',
               ),
-              label: l10n.tabMyPage,
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(
-                Icons.settings,
-                semanticLabel: 'settingIcon',
+              BottomNavigationBarItem(
+                icon: Padding(
+                  padding: const EdgeInsets.only(top: 18),
+                  child: Icon(
+                    Icons.settings,
+                    semanticLabel: 'settingIcon',
+                  ),
+                ),
+                label: '',
               ),
-              label: l10n.tabSetting,
-            ),
-          ],
-          type: BottomNavigationBarType.fixed,
-          iconSize: 28,
-          elevation: 0,
-          backgroundColor: Colors.white,
-          selectedItemColor: Colors.black,
-          unselectedItemColor: Colors.grey,
-          selectedFontSize: 8,
-          unselectedFontSize: 8,
+            ],
+            type: BottomNavigationBarType.fixed,
+            iconSize: 28,
+            elevation: 0,
+            backgroundColor: Colors.white,
+            selectedItemColor: Colors.black,
+            unselectedItemColor: Colors.grey,
+            selectedFontSize: 0,
+            unselectedFontSize: 0,
+          ),
         ),
       ),
     );

--- a/lib/ui/screen/time_line/component/story_page.dart
+++ b/lib/ui/screen/time_line/component/story_page.dart
@@ -19,88 +19,92 @@ class StoryPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: StoryPageView(
-        itemBuilder: (context, pageIndex, storyIndex) {
-          return Stack(
-            children: [
-              Positioned.fill(child: Container(color: Colors.black)),
-              Positioned.fill(
-                child: CachedNetworkImage(
-                  imageUrl: supabase.storage
-                      .from('food')
-                      .getPublicUrl(posts.foodImage),
-                  fit: BoxFit.fitWidth,
+      backgroundColor: Colors.black,
+      body: Padding(
+        padding: const EdgeInsets.only(top: 10),
+        child: StoryPageView(
+          itemBuilder: (context, pageIndex, storyIndex) {
+            return Stack(
+              children: [
+                Positioned.fill(child: Container(color: Colors.black)),
+                Positioned.fill(
+                  child: CachedNetworkImage(
+                    imageUrl: supabase.storage
+                        .from('food')
+                        .getPublicUrl(posts.foodImage),
+                    fit: BoxFit.fitWidth,
+                  ),
                 ),
-              ),
-              Padding(
-                padding: const EdgeInsets.only(top: 44, left: 8),
-                child: Row(
-                  children: [
-                    CircleAvatar(
-                      radius: 28,
-                      backgroundImage: AssetImage(users.image),
-                      backgroundColor: Colors.white,
-                    ),
-                    Gap(12),
-                    Text(
-                      users.name,
-                      style: TextStyle(
-                        fontSize: 16,
-                        color: Colors.white,
-                        fontWeight: FontWeight.bold,
+                Padding(
+                  padding: const EdgeInsets.only(top: 44, left: 8),
+                  child: Row(
+                    children: [
+                      CircleAvatar(
+                        radius: 28,
+                        backgroundImage: AssetImage(users.image),
+                        backgroundColor: Colors.white,
                       ),
-                    ),
-                  ],
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Spacer(),
-                    Text(
-                      posts.restaurant,
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontWeight: FontWeight.bold,
-                        fontSize: 20,
+                      Gap(12),
+                      Text(
+                        users.name,
+                        style: TextStyle(
+                          fontSize: 16,
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
-                    ),
-                    Text(
-                      posts.foodTag,
-                      style: TextStyle(fontSize: 40),
-                    ),
-                    Gap(50),
-                  ],
+                    ],
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Spacer(),
+                      Text(
+                        posts.restaurant,
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 20,
+                        ),
+                      ),
+                      Text(
+                        posts.foodTag,
+                        style: TextStyle(fontSize: 40),
+                      ),
+                      Gap(50),
+                    ],
+                  ),
+                ),
+              ],
+            );
+          },
+          gestureItemBuilder: (context, pageIndex, storyIndex) {
+            return Align(
+              alignment: Alignment.topRight,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 32),
+                child: IconButton(
+                  padding: EdgeInsets.zero,
+                  color: Colors.white,
+                  icon: Icon(Icons.close),
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
                 ),
               ),
-            ],
-          );
-        },
-        gestureItemBuilder: (context, pageIndex, storyIndex) {
-          return Align(
-            alignment: Alignment.topRight,
-            child: Padding(
-              padding: const EdgeInsets.only(top: 32),
-              child: IconButton(
-                padding: EdgeInsets.zero,
-                color: Colors.white,
-                icon: Icon(Icons.close),
-                onPressed: () {
-                  Navigator.pop(context);
-                },
-              ),
-            ),
-          );
-        },
-        pageLength: 1,
-        storyLength: (pageIndex) {
-          return 1;
-        },
-        onPageLimitReached: () {
-          Navigator.pop(context);
-        },
+            );
+          },
+          pageLength: 1,
+          storyLength: (pageIndex) {
+            return 1;
+          },
+          onPageLimitReached: () {
+            Navigator.pop(context);
+          },
+        ),
       ),
     );
   }

--- a/lib/ui/screen/time_line/time_line_screen.dart
+++ b/lib/ui/screen/time_line/time_line_screen.dart
@@ -20,12 +20,12 @@ class TimeLineScreen extends ConsumerWidget {
       child: Scaffold(
         backgroundColor: Colors.white,
         appBar: PreferredSize(
-          preferredSize: Size.fromHeight(55),
+          preferredSize: Size.fromHeight(40),
           child: AppBar(
             surfaceTintColor: Colors.transparent,
             forceMaterialTransparency: true,
             elevation: 0,
-            bottom: const TabBar(
+            bottom: TabBar(
               indicatorWeight: 1,
               automaticIndicatorColorAdjustment: false,
               labelStyle: TextStyle(fontSize: 12),
@@ -35,14 +35,12 @@ class TimeLineScreen extends ConsumerWidget {
               indicatorSize: TabBarIndicatorSize.tab,
               tabs: <Widget>[
                 Tab(
-                  icon: Icon(Icons.dinner_dining),
-                  text: 'レストラン',
-                  height: 50,
+                  icon: Icon(Icons.dinner_dining, size: 30),
+                  height: 38,
                 ),
                 Tab(
-                  icon: Icon(Icons.restaurant_menu),
-                  text: '自炊',
-                  height: 50,
+                  icon: Icon(Icons.restaurant_menu, size: 30),
+                  height: 38,
                 ),
               ],
             ),

--- a/lib/utils/url_launch.dart
+++ b/lib/utils/url_launch.dart
@@ -11,20 +11,15 @@ class LaunchUrl {
     }
   }
 
-  Future<bool> openSNSUrl(
-    String url,
-    String secondUrl,
-  ) async {
-    final snsUrl = Uri.parse(url);
-    final snsSecondUrk = Uri.parse(secondUrl);
-    if (await canLaunchUrl(snsUrl)) {
-      await launchUrl(snsUrl);
-      return true;
-    } else if (await canLaunchUrl(snsSecondUrk)) {
-      await launchUrl(snsSecondUrk);
-      return true;
-    } else {
+  Future<bool> openSNSUrl(String url) async {
+    final canLaunch = await canLaunchUrl(Uri.parse(url));
+    if (!canLaunch) {
       return false;
     }
+
+    return launchUrl(
+      Uri.parse(url),
+      mode: LaunchMode.externalApplication,
+    );
   }
 }


### PR DESCRIPTION
## Issue

- close #422 
- close #423 
- close #424 
- close #425 

## 概要

- 設定画面のTwitterアカウントをFoodGramのアカウントに差し替える
- タブ画面の名称を削除してもいいかも
- 設定画面のいくつかにloadingをつけてあげる
- ストーリー画面をもう少し上にする

## 追加したPackage

-

## Screenshot

| TH | TH |
| ---- | ---- |
| ![IMG_8535](https://github.com/user-attachments/assets/f3795f99-9430-431b-a486-e2a26662483a) | ![スクリーンショット 2024-11-26 午後1 50 24 2](https://github.com/user-attachments/assets/e34ed1a6-f6ae-4893-ac8c-e60aac88a499) |





## 備考

