### PR TITLE
マップ画面で現在地に移動するFloatingButtonを実装する

### DIFF
--- a/lib/ui/component/app_list_view.dart
+++ b/lib/ui/component/app_list_view.dart
@@ -49,8 +49,8 @@ class AppListView extends ConsumerWidget {
                       return GestureDetector(
                         onTap: () async {
                           EasyDebounce.debounce(
-                            'click detail',
-                            Duration.zero,
+                            'click_detail',
+                            const Duration(milliseconds: 300),
                             () async {
                               final post = await ref
                                   .read(postsServiceProvider)

--- a/lib/ui/component/app_list_view.dart
+++ b/lib/ui/component/app_list_view.dart
@@ -77,6 +77,9 @@ class AppListView extends ConsumerWidget {
                               fit: BoxFit.cover,
                               width: screenWidth,
                               height: screenWidth,
+                              placeholder: (context, url) => Container(
+                                color: Colors.white,
+                              ),
                             ),
                           ),
                         ),

--- a/lib/ui/component/app_list_view.dart
+++ b/lib/ui/component/app_list_view.dart
@@ -19,11 +19,12 @@ class AppListView extends ConsumerWidget {
 
   final List<Map<String, dynamic>> data;
   final String routerPath;
-  final Function() refresh;
+  final VoidCallback refresh;
   final bool isTimeLine;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final screenWidth = MediaQuery.of(context).size.width / 3;
     return data.isNotEmpty
         ? RefreshIndicator(
             color: Colors.black,
@@ -40,14 +41,16 @@ class AppListView extends ConsumerWidget {
                       height: 100,
                       child: StoryWidget(data: data),
                     ),
-                  )
-                else
-                  SliverToBoxAdapter(child: SizedBox()),
+                  ),
                 SliverGrid(
                   delegate: SliverChildBuilderDelegate(
                     (context, index) {
+                      final foodImageUrl = supabase.storage
+                          .from('food')
+                          .getPublicUrl(data[index]['food_image']);
+
                       return GestureDetector(
-                        onTap: () async {
+                        onTap: () {
                           EasyDebounce.debounce(
                             'click_detail',
                             const Duration(milliseconds: 300),
@@ -55,16 +58,13 @@ class AppListView extends ConsumerWidget {
                               final post = await ref
                                   .read(postsServiceProvider)
                                   .getPost(data, index);
-                              await context
-                                  .pushNamed(
+                              final result = await context.pushNamed(
                                 routerPath,
                                 extra: post,
-                              )
-                                  .then((value) {
-                                if (value != null) {
-                                  refresh();
-                                }
-                              });
+                              );
+                              if (result != null) {
+                                refresh();
+                              }
                             },
                           );
                         },
@@ -72,16 +72,11 @@ class AppListView extends ConsumerWidget {
                           elevation: 10,
                           child: ClipRRect(
                             borderRadius: BorderRadius.circular(10),
-                            child: Container(
-                              width: MediaQuery.of(context).size.width / 3,
-                              height: MediaQuery.of(context).size.width / 3,
-                              color: Colors.white,
-                              child: CachedNetworkImage(
-                                imageUrl: supabase.storage
-                                    .from('food')
-                                    .getPublicUrl(data[index]['food_image']),
-                                fit: BoxFit.cover,
-                              ),
+                            child: CachedNetworkImage(
+                              imageUrl: foodImageUrl,
+                              fit: BoxFit.cover,
+                              width: screenWidth,
+                              height: screenWidth,
                             ),
                           ),
                         ),
@@ -98,6 +93,6 @@ class AppListView extends ConsumerWidget {
               ],
             ),
           )
-        : AppEmpty();
+        : const AppEmpty();
   }
 }

--- a/lib/ui/screen/map/component/map_floating_action_button.dart
+++ b/lib/ui/screen/map/component/map_floating_action_button.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class MapFloatingActionButton extends StatelessWidget {
+  const MapFloatingActionButton({
+    required this.onPressed,
+    super.key,
+  });
+
+  final Function() onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8),
+      child: Container(
+        width: 60,
+        height: 60,
+        child: FloatingActionButton(
+          heroTag: null,
+          foregroundColor: Colors.white,
+          backgroundColor: Colors.white,
+          elevation: 10,
+          shape: CircleBorder(side: BorderSide(color: Colors.white)),
+          onPressed: onPressed,
+          child: Icon(
+            CupertinoIcons.location_fill,
+            color: Color(0xFF1A73E8),
+            size: 25,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/screen/map/map_screen.dart
+++ b/lib/ui/screen/map/map_screen.dart
@@ -6,6 +6,7 @@ import 'package:food_gram_app/core/utils/async_value_group.dart';
 import 'package:food_gram_app/core/utils/location.dart';
 import 'package:food_gram_app/env.dart';
 import 'package:food_gram_app/ui/component/modal_sheet/app_map_restaurant_modal_sheet.dart';
+import 'package:food_gram_app/ui/screen/map/component/map_floating_action_button.dart';
 import 'package:food_gram_app/ui/screen/map/maplibre_controller.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
@@ -66,6 +67,11 @@ class MapScreen extends HookConsumerWidget {
               ),
             ],
           );
+        },
+      ),
+      floatingActionButton: MapFloatingActionButton(
+        onPressed: () {
+          ref.read(mapLibreControllerProvider.notifier).moveToCurrentLocation();
         },
       ),
     );

--- a/lib/ui/screen/map/map_screen.dart
+++ b/lib/ui/screen/map/map_screen.dart
@@ -57,6 +57,7 @@ class MapScreen extends HookConsumerWidget {
                   zoom: 15,
                 ),
                 trackCameraPosition: true,
+                tiltGesturesEnabled: false,
                 styleString: '$styleUrl?key=$apiKey',
               ),
               Visibility(

--- a/lib/ui/screen/map/maplibre_controller.dart
+++ b/lib/ui/screen/map/maplibre_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:food_gram_app/core/data/supabase/service/posts_service.dart';
 import 'package:food_gram_app/core/model/posts.dart';
+import 'package:food_gram_app/core/utils/location.dart';
 import 'package:food_gram_app/gen/assets.gen.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -48,5 +49,20 @@ class MapLibreController extends _$MapLibreController {
         duration: Duration(seconds: 2),
       );
     });
+  }
+
+  Future<void> moveToCurrentLocation() async {
+    final currentLocation = ref.read(locationProvider);
+    await currentLocation.whenOrNull(
+      data: (location) async {
+        final currentLatLng = LatLng(
+          location.latitude,
+          location.longitude,
+        );
+        await controller.animateCamera(
+          CameraUpdate.newLatLngZoom(currentLatLng, 15),
+        );
+      },
+    );
   }
 }


### PR DESCRIPTION
## Issue

- close #438 
- close #439 
- close #440 
- close #441 

## 概要

- マップ画面で現在地に移動するFloatingButtonを実装する
- 投稿詳細への遷移を1回だけに制御できるようにしたい
- 傾きジェスチャーを使用しないようにする
- appListViewのリファクタリング

## 追加したPackage

-

## Screenshot


## 備考

