### PR TITLE
インタースティシャル広告の読み込みの時間によって強制的に処理を呼べるようにする

### DIFF
--- a/lib/core/data/admob/admob_interstitial.dart
+++ b/lib/core/data/admob/admob_interstitial.dart
@@ -63,6 +63,7 @@ class AdmobInterstitial {
   Future<void> showAd({VoidCallback? onAdClosed}) async {
     if (!_isAdReady || _interstitialAd == null) {
       logger.e('Attempted to show ad before it was ready');
+      onAdClosed?.call();
       return;
     }
 
@@ -79,14 +80,14 @@ class AdmobInterstitial {
         logger.i('Ad dismissed');
         ad.dispose();
         _isAdReady = false;
-        createAd(); // 再ロード
+        createAd();
         onAdClosed?.call();
       },
       onAdFailedToShowFullScreenContent: (ad, error) {
         logger.e('Failed to show ad: $error');
         ad.dispose();
         _isAdReady = false;
-        createAd(); // 再ロード
+        createAd();
       },
     );
 

--- a/lib/ui/component/dialog/app_share_dialog.dart
+++ b/lib/ui/component/dialog/app_share_dialog.dart
@@ -32,13 +32,14 @@ class AppShareDialog extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = L10n.of(context);
     final loading = useState(false);
-    final adInterstitial = ref.watch(admobInterstitialNotifierProvider);
+    final adInterstitial =
+        useMemoized(() => ref.read(admobInterstitialNotifierProvider));
     useEffect(
       () {
         adInterstitial.createAd();
-        return null;
+        return;
       },
-      [],
+      [adInterstitial],
     );
     return Scaffold(
       backgroundColor: Colors.black.withValues(alpha: 0.8),

--- a/lib/ui/screen/detail/detail_post_screen.dart
+++ b/lib/ui/screen/detail/detail_post_screen.dart
@@ -49,10 +49,19 @@ class DetailPostScreen extends HookConsumerWidget {
     final initialHeart = useState(posts.heart);
     final isSnowing = useState(false);
     final tickerProvider = useSingleTickerProvider();
-    final adInterstitial = ref.watch(admobInterstitialNotifierProvider);
+    final adInterstitial =
+        useMemoized(() => ref.read(admobInterstitialNotifierProvider));
     final gifController = useMemoized(
       () => GifController(vsync: tickerProvider),
       [tickerProvider],
+    );
+
+    useEffect(
+      () {
+        adInterstitial.createAd();
+        return gifController.dispose;
+      },
+      [gifController, adInterstitial],
     );
     useEffect(
       () {

--- a/lib/ui/screen/detail/detail_post_screen.dart
+++ b/lib/ui/screen/detail/detail_post_screen.dart
@@ -83,21 +83,23 @@ class DetailPostScreen extends HookConsumerWidget {
           backgroundColor: Colors.white,
           automaticallyImplyLeading: !loading,
           surfaceTintColor: Colors.transparent,
-          leading: !loading
-              ? GestureDetector(
+          leading: loading || menuLoading.value
+              ? SizedBox.shrink()
+              : GestureDetector(
                   onTap: () => context.pop(),
                   child: Icon(
                     Icons.close,
                     size: 30,
                   ),
-                )
-              : SizedBox.shrink(),
+                ),
           title: GestureDetector(
             onTap: () => isSnowing.value = !isSnowing.value,
             child: Text('     '),
           ),
           actions: [
-            if (!loading)
+            if (loading || menuLoading.value)
+              SizedBox.shrink()
+            else
               IconButton(
                 onPressed: () {
                   showModalBottomSheet(
@@ -127,7 +129,7 @@ class DetailPostScreen extends HookConsumerWidget {
                   Icons.menu,
                   color: Colors.black,
                 ),
-              ),
+              )
           ],
         ),
         body: SafeArea(

--- a/lib/ui/screen/edit/edit_screen.dart
+++ b/lib/ui/screen/edit/edit_screen.dart
@@ -28,13 +28,14 @@ class EditScreen extends HookConsumerWidget {
     final isSubscribed =
         subscriptionState.whenOrNull(data: (isSubscribed) => isSubscribed) ??
             false;
-    final adInterstitial = ref.watch(admobInterstitialNotifierProvider);
+    final adInterstitial =
+        useMemoized(() => ref.read(admobInterstitialNotifierProvider));
     useEffect(
       () {
         adInterstitial.createAd();
-        return null;
+        return;
       },
-      [],
+      [adInterstitial],
     );
     return PopScope(
       canPop: !loading,


### PR DESCRIPTION
## Issue

- close #506 
- close #505 

## 概要

- インタースティシャル広告の読み込みの時間によって強制的に処理を呼べるようにする
- 詳細画面のLoading中に戻れないようにしたい

## 追加したPackage

- なし

## Screenshot

![スクリーンショット 2025-01-20 午前11 47 00](https://github.com/user-attachments/assets/1b1dad8d-c86c-457b-ba47-a3f52a44d67c)


## 備考

