### PR TITLE
投稿詳細の調べるボタンがマップを開いてしまう不具合を直す

### DIFF
--- a/lib/core/config/constants/url.dart
+++ b/lib/core/config/constants/url.dart
@@ -15,6 +15,6 @@ class URL {
   static const report =
       'https://docs.google.com/forms/d/1uDNHpaPTNPK7tBjbfNW87ykYH3JZO0D2l10oBtVxaQA/edit';
 
-  static String search(String restaurant) =>
+  static String go(String restaurant) =>
       'https://www.google.com/maps/search/?api=1&query=$restaurant';
 }

--- a/lib/core/config/constants/url.dart
+++ b/lib/core/config/constants/url.dart
@@ -17,4 +17,7 @@ class URL {
 
   static String go(String restaurant) =>
       'https://www.google.com/maps/search/?api=1&query=$restaurant';
+
+  static String search(String restaurant) =>
+      'https://www.google.com/search?q=$restaurant';
 }

--- a/lib/ui/component/modal_sheet/app_detail_my_info_modal_sheet.dart
+++ b/lib/ui/component/modal_sheet/app_detail_my_info_modal_sheet.dart
@@ -132,7 +132,7 @@ class AppDetailMyInfoModalSheet extends ConsumerWidget {
                   onPressed: () async {
                     context.pop();
                     if (posts.restaurant != '不明' && posts.restaurant != '自炊') {
-                      await LaunchUrl().open(URL.search(posts.restaurant));
+                      await LaunchUrl().open(URL.go(posts.restaurant));
                     } else {
                       openErrorSnackBar(context, l10n.postSearchError, '');
                     }

--- a/lib/ui/component/modal_sheet/app_detail_other_info_modal_sheet.dart
+++ b/lib/ui/component/modal_sheet/app_detail_other_info_modal_sheet.dart
@@ -132,7 +132,7 @@ class AppDetailOtherInfoModalSheet extends ConsumerWidget {
                   onPressed: () async {
                     context.pop();
                     if (posts.restaurant != '不明' && posts.restaurant != '自炊') {
-                      await LaunchUrl().open(URL.search(posts.restaurant));
+                      await LaunchUrl().open(URL.go(posts.restaurant));
                     } else {
                       openErrorSnackBar(context, l10n.postSearchError, '');
                     }


### PR DESCRIPTION
## Issue

- close #512 

## 概要

- 投稿詳細の調べるボタンがマップを開いてしまう不具合を直す

## 追加したPackage

- なし

## Screenshot


https://github.com/user-attachments/assets/1a68862d-f746-4b56-8d38-ed52b995e929


## 備考

