### PR TITLE
投稿詳細の「行く」とかのボタンをなんとか１行で収める調整をする

### DIFF
--- a/lib/ui/component/app_elevated_button.dart
+++ b/lib/ui/component/app_elevated_button.dart
@@ -56,6 +56,7 @@ class AppDetailElevatedButton extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 2),
       child: ElevatedButton(
         style: ElevatedButton.styleFrom(
+          padding: EdgeInsets.symmetric(horizontal: 12),
           elevation: 0,
           backgroundColor: Color(0xFFEFEFEF),
           foregroundColor: Colors.black,
@@ -71,7 +72,7 @@ class AppDetailElevatedButton extends StatelessWidget {
               color: Colors.black,
               size: 20,
             ),
-            Gap(8),
+            Gap(4),
             Text(
               title,
               style: TextStyle(

--- a/lib/ui/screen/detail/detail_post_screen.dart
+++ b/lib/ui/screen/detail/detail_post_screen.dart
@@ -315,9 +315,9 @@ class DetailPostScreen extends HookConsumerWidget {
                     ),
                     Gap(6),
                     Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
                       child: SizedBox(
-                        height: 40,
+                        height: 38,
                         child: ListView(
                           scrollDirection: Axis.horizontal,
                           children: [


### PR DESCRIPTION
## Issue

- close #548 

## 概要

- 投稿詳細の「行く」とかのボタンをなんとか１行で収める調整をする
  - Paddingや高さを調整した 

## 追加したPackage

- なし

## Screenshot

| TH | TH |
| ---- | ---- |
| ![IMG_9563](https://github.com/user-attachments/assets/e0f76a43-7b6c-4f1c-8613-3c68cd5f3739) | ![スクリーンショット 2025-02-10 午後6 25 52](https://github.com/user-attachments/assets/679577cf-9d6e-4614-b689-e4aed02133ca) |



## 備考

