### PR TITLE
アカウント作成画面で注意事項を書いておく

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -145,5 +145,10 @@
   "postCameraPermission": "Camera permission is required",
   "postAlbumPermission": "Photo library permission is required",
   "postSuccess": "Post successful",
-  "searchButton":"Search"
+  "searchButton":"Search",
+  "newAccountImportantTitle": "Important Note",
+  "newAccountImportant": "When creating an account, please do not include personal information such as your email address or phone number in your username or user ID. To ensure a safe online experience, choose a name that does not reveal your personal details.",
+  "accountRegistrationSuccess": "Account registration completed",
+  "accountRegistrationError": "An error occurred",
+  "requiredInfoMissing": "Required information is missing"
 }

--- a/assets/l10n/app_ja.arb
+++ b/assets/l10n/app_ja.arb
@@ -145,5 +145,10 @@
   "postCameraPermission": "カメラの許可が必要です",
   "postAlbumPermission": "フォトライブラリの許可が必要です",
   "postSuccess": "投稿が完了しました",
-  "searchButton":"検索"
+  "searchButton":"検索",
+  "newAccountImportantTitle": "重要な注意事項",
+  "newAccountImportant": "アカウントを作成する際、ユーザー名やユーザーIDには、メールアドレスや電話番号などの個人情報を含めないようにしてください。安全なオンライン体験のため、個人情報が特定されない名前を設定してください。",
+  "accountRegistrationSuccess": "アカウントの登録が完了しました",
+  "accountRegistrationError": "エラーが発生しました",
+  "requiredInfoMissing": "必要な情報が入力されていません"
 }

--- a/lib/core/utils/helpers/snack_bar_helper.dart
+++ b/lib/core/utils/helpers/snack_bar_helper.dart
@@ -17,7 +17,7 @@ class SnackBarHelper {
         message: message,
         contentType: ContentType.failure,
         titleTextStyle: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-        messageTextStyle: TextStyle(fontSize: 12),
+        messageTextStyle: TextStyle(fontSize: 14),
       ),
     );
     ScaffoldMessenger.of(context)

--- a/lib/gen/l10n/l10n.dart
+++ b/lib/gen/l10n/l10n.dart
@@ -971,6 +971,36 @@ abstract class L10n {
   /// In ja, this message translates to:
   /// **'検索'**
   String get searchButton;
+
+  /// No description provided for @newAccountImportantTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'重要な注意事項'**
+  String get newAccountImportantTitle;
+
+  /// No description provided for @newAccountImportant.
+  ///
+  /// In ja, this message translates to:
+  /// **'アカウントを作成する際、ユーザー名やユーザーIDには、メールアドレスや電話番号などの個人情報を含めないようにしてください。安全なオンライン体験のため、個人情報が特定されない名前を設定してください。'**
+  String get newAccountImportant;
+
+  /// No description provided for @accountRegistrationSuccess.
+  ///
+  /// In ja, this message translates to:
+  /// **'アカウントの登録が完了しました'**
+  String get accountRegistrationSuccess;
+
+  /// No description provided for @accountRegistrationError.
+  ///
+  /// In ja, this message translates to:
+  /// **'エラーが発生しました'**
+  String get accountRegistrationError;
+
+  /// No description provided for @requiredInfoMissing.
+  ///
+  /// In ja, this message translates to:
+  /// **'必要な情報が入力されていません'**
+  String get requiredInfoMissing;
 }
 
 class _L10nDelegate extends LocalizationsDelegate<L10n> {

--- a/lib/gen/l10n/l10n_en.dart
+++ b/lib/gen/l10n/l10n_en.dart
@@ -445,4 +445,19 @@ class L10nEn extends L10n {
 
   @override
   String get searchButton => 'Search';
+
+  @override
+  String get newAccountImportantTitle => 'Important Note';
+
+  @override
+  String get newAccountImportant => 'When creating an account, please do not include personal information such as your email address or phone number in your username or user ID. To ensure a safe online experience, choose a name that does not reveal your personal details.';
+
+  @override
+  String get accountRegistrationSuccess => 'Account registration completed';
+
+  @override
+  String get accountRegistrationError => 'An error occurred';
+
+  @override
+  String get requiredInfoMissing => 'Required information is missing';
 }

--- a/lib/gen/l10n/l10n_ja.dart
+++ b/lib/gen/l10n/l10n_ja.dart
@@ -445,4 +445,19 @@ class L10nJa extends L10n {
 
   @override
   String get searchButton => '検索';
+
+  @override
+  String get newAccountImportantTitle => '重要な注意事項';
+
+  @override
+  String get newAccountImportant => 'アカウントを作成する際、ユーザー名やユーザーIDには、メールアドレスや電話番号などの個人情報を含めないようにしてください。安全なオンライン体験のため、個人情報が特定されない名前を設定してください。';
+
+  @override
+  String get accountRegistrationSuccess => 'アカウントの登録が完了しました';
+
+  @override
+  String get accountRegistrationError => 'エラーが発生しました';
+
+  @override
+  String get requiredInfoMissing => '必要な情報が入力されていません';
 }

--- a/lib/ui/screen/new_account/new_account_screen.dart
+++ b/lib/ui/screen/new_account/new_account_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:food_gram_app/core/utils/helpers/snack_bar_helper.dart';
 import 'package:food_gram_app/core/utils/provider/loading.dart';
 import 'package:food_gram_app/gen/l10n/l10n.dart';
 import 'package:food_gram_app/router/router.dart';
@@ -19,11 +20,29 @@ class NewAccountScreen extends ConsumerWidget {
     final loading = ref.watch(loadingProvider);
     final controller = ref.watch(newAccountViewModelProvider().notifier);
     final state = ref.watch(newAccountViewModelProvider());
+    ref.listen(newAccountViewModelProvider(), (previous, current) {
+      if (current.loginStatus.isNotEmpty &&
+          previous?.loginStatus != current.loginStatus) {
+        var message = '';
+        switch (current.loginStatus) {
+          case 'account_registration_error':
+            message = L10n.of(context).accountRegistrationError;
+            SnackBarHelper().openErrorSnackBar(context, '', message);
+            break;
+          case 'required_info_missing':
+            message = L10n.of(context).requiredInfoMissing;
+            SnackBarHelper().openErrorSnackBar(context, '', message);
+            break;
+          default:
+            message = current.loginStatus;
+        }
+      }
+    });
+
     return GestureDetector(
       onTap: () => primaryFocus?.unfocus(),
       child: Scaffold(
         backgroundColor: Colors.white,
-        appBar: AppBar(backgroundColor: Colors.white),
         body: Stack(
           children: [
             SingleChildScrollView(
@@ -31,22 +50,23 @@ class NewAccountScreen extends ConsumerWidget {
                 padding: const EdgeInsets.symmetric(horizontal: 15),
                 child: Column(
                   children: [
+                    Gap(20),
                     CircleAvatar(
                       backgroundColor: Colors.white,
                       backgroundImage:
                           AssetImage('assets/icon/icon${state.number}.png'),
                       radius: 60,
                     ),
-                    Gap(10),
+                    const Gap(10),
                     Text(
                       L10n.of(context).settingsIcon,
-                      style: TextStyle(
+                      style: const TextStyle(
                         fontWeight: FontWeight.bold,
                         fontSize: 18,
                         color: Colors.black,
                       ),
                     ),
-                    Gap(10),
+                    const Gap(10),
                     Wrap(
                       children: List.generate(
                         6,
@@ -60,15 +80,15 @@ class NewAccountScreen extends ConsumerWidget {
                         },
                       ),
                     ),
-                    Gap(30),
+                    const Gap(30),
                     AppNameTextField(
                       controller: controller.nameTextController,
                     ),
-                    Gap(30),
+                    const Gap(20),
                     AppUserNameTextField(
                       controller: controller.userNameTextController,
                     ),
-                    Gap(30),
+                    const Gap(20),
                     AppElevatedButton(
                       onPressed: () {
                         ref
@@ -82,15 +102,7 @@ class NewAccountScreen extends ConsumerWidget {
                       },
                       title: L10n.of(context).registerButton,
                     ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 15),
-                      child: Text(
-                        state.loginStatus,
-                        style: TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
-                        ),
-                    const Gap(30),
+                    const Gap(20),
                     Text(
                       L10n.of(context).newAccountImportantTitle,
                       style: const TextStyle(

--- a/lib/ui/screen/new_account/new_account_screen.dart
+++ b/lib/ui/screen/new_account/new_account_screen.dart
@@ -90,6 +90,20 @@ class NewAccountScreen extends ConsumerWidget {
                           fontSize: 18,
                           fontWeight: FontWeight.bold,
                         ),
+                    const Gap(30),
+                    Text(
+                      L10n.of(context).newAccountImportantTitle,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 18,
+                      ),
+                    ),
+                    const Gap(10),
+                    Text(
+                      L10n.of(context).newAccountImportant,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        fontSize: 16,
                       ),
                     ),
                   ],

--- a/lib/ui/screen/new_account/new_account_view_model.dart
+++ b/lib/ui/screen/new_account/new_account_view_model.dart
@@ -41,14 +41,11 @@ class NewAccountViewModel extends _$NewAccountViewModel {
           );
       result.when(
         success: (_) {
-          state = state.copyWith(
-            loginStatus: 'アカウントの登録が完了しました',
-            isSuccess: true,
-          );
+          state = state.copyWith(isSuccess: true);
         },
         failure: (_) {
           state = state.copyWith(
-            loginStatus: 'エラーが発生しました',
+            loginStatus: 'account_registration_error',
             isSuccess: false,
           );
         },
@@ -56,7 +53,8 @@ class NewAccountViewModel extends _$NewAccountViewModel {
       loading.state = false;
       return state.isSuccess;
     } else {
-      state = state.copyWith(loginStatus: '必要な情報が入力されていません');
+      state = state.copyWith(loginStatus: 'required_info_missing');
+      loading.state = false;
       return false;
     }
   }


### PR DESCRIPTION
## Issue

- close #582 

## 概要

- アカウント作成画面で注意事項を書いておく

- [x]  注意事項とその内容をWidgetに追加する
- [x]  NewAccount画面のリファクタリングをする
- [x]  NewAccountViewModelのリファクタリング
    - [x]  ログインの状態を管理する状態をWidgetでSnackBarにする

## 追加したPackage

- なし

## Screenshot

| TH | TH |
| ---- | ---- |
| ![IMG_9581](https://github.com/user-attachments/assets/4cd9476e-d20a-42d4-bf15-99f151ef42ad) | ![IMG_9584](https://github.com/user-attachments/assets/6f52f5a6-b192-48aa-8995-c4c3bd250697) |







## 備考

