### PR TITLE
マップのスタイルをopenstreetmapに切り替え

### DIFF
--- a/lib/ui/screen/map/map_screen.dart
+++ b/lib/ui/screen/map/map_screen.dart
@@ -13,8 +13,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 
 final String apiKey = Env.mapLibre;
-const styleUrl =
-    'https://api.maptiler.com/maps/a38db0e5-171e-4317-9a13-6b406c609e21/style.json';
 
 class MapScreen extends HookConsumerWidget {
   const MapScreen({super.key});
@@ -67,7 +65,8 @@ class MapScreen extends HookConsumerWidget {
                     ),
                     trackCameraPosition: true,
                     tiltGesturesEnabled: false,
-                    styleString: '$styleUrl?key=$apiKey',
+                    styleString:
+                        'https://tile.openstreetmap.jp/styles/maptiler-basic-ja/style.json',
                   ),
                   Visibility(
                     visible: isTapPin.value,


### PR DESCRIPTION
## Issue

- close #591 

## 概要

- マップのスタイルをopenstreetmapに切り替え
- 使用料がやばそうだから一度オープンソースで使えるスタイルを使うことにした

## 追加したPackage

- なし

## Screenshot


![IMG_ED02DC4B259F-1](https://github.com/user-attachments/assets/89405f2d-f511-44a6-9cc6-5509918e07b4)



## 備考

