### PR TITLE
Androidでボタンとタブが重なってしまっている不具合を治す

### DIFF
--- a/lib/ui/screen/tab/tab_screen.dart
+++ b/lib/ui/screen/tab/tab_screen.dart
@@ -41,7 +41,6 @@ class TabScreen extends ConsumerWidget {
                       state.selectedIndex == 0
                           ? CupertinoIcons.map_fill
                           : CupertinoIcons.map,
-                      semanticLabel: 'mapIcon',
                     ),
                     const Gap(6),
                     Text(
@@ -61,7 +60,6 @@ class TabScreen extends ConsumerWidget {
                       state.selectedIndex == 1
                           ? Icons.fastfood
                           : Icons.fastfood_outlined,
-                      semanticLabel: 'timelineIcon',
                     ),
                     const Gap(6),
                     Text(
@@ -82,7 +80,6 @@ class TabScreen extends ConsumerWidget {
                           ? CupertinoIcons.search_circle_fill
                           : CupertinoIcons.search_circle,
                       size: 30,
-                      semanticLabel: 'profileIcon',
                     ),
                     const Gap(6),
                     Text(
@@ -103,7 +100,6 @@ class TabScreen extends ConsumerWidget {
                           ? CupertinoIcons.person_circle_fill
                           : CupertinoIcons.person_circle,
                       size: 30,
-                      semanticLabel: 'profileIcon',
                     ),
                     const Gap(6),
                     Text(
@@ -123,7 +119,6 @@ class TabScreen extends ConsumerWidget {
                       state.selectedIndex == 4
                           ? Icons.settings
                           : Icons.settings_outlined,
-                      semanticLabel: 'settingIcon',
                     ),
                     const Gap(6),
                     Text(


### PR DESCRIPTION
## Issue

- close #701 

## 概要

- Androidでボタンとタブが重なってしまっている不具合を治す
  - iOSの場合はUI自体は変えないようにする 

## 追加したPackage

- なし

## Screenshot

| Android | iOS |
| ---- | ---- |
| ![Screenshot_20250702-105056](https://github.com/user-attachments/assets/7a45845c-c79f-4398-9b41-b2a7f1f0a1d3) | ![スクリーンショット 2025-07-02 午前10 51 52](https://github.com/user-attachments/assets/9a8da07d-708b-4936-82fb-feb3d1d0a908) |




## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved platform-specific UI adjustments for iOS and non-iOS devices, ensuring better padding and safe area handling.
  * Simplified icon selection logic in the bottom navigation bar.
  * Removed semantic labels from navigation icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->