### PR TITLE
レストラン検索画面の「もっとみる」を押すと近いレストランんだけしか取得できていない不具合を修正しました

### DIFF
--- a/lib/ui/screen/search/search_screen.dart
+++ b/lib/ui/screen/search/search_screen.dart
@@ -146,9 +146,11 @@ class SearchScreen extends HookConsumerWidget {
                             ),
                           ),
                           TextButton(
-                            onPressed: nearbyPosts.hasValue
+                            onPressed: postState.hasValue
                                 ? () {
-                                    final posts = nearbyPosts.value!;
+                                    final posts = postState.value!
+                                        .map(Posts.fromJson)
+                                        .toList();
                                     context.pushNamed(
                                       RouterPath.searchDetail,
                                       extra: posts,


### PR DESCRIPTION
## Issue

- close #721 

## 概要

- レストラン検索画面の「もっとみる」を押すと近いレストランんだけしか取得できていない不具合を修正しました

## 追加したPackage

- なし

## Screenshot


https://github.com/user-attachments/assets/0ad9c783-d1de-43b0-b9fb-1da819dc4b25



## 備考

