### PR TITLE
投稿のエラー表示の出し分けを正しくする

### DIFF
--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -54,6 +54,9 @@
   "postCuisineCategory": "Cuisine",
   "postTitle":"Post",
   "postMissingInfo": "Please fill in all required fields",
+  "postMissingPhoto": "Please add a photo",
+  "postMissingFoodName": "Please enter what you ate",
+  "postMissingRestaurant": "Please add restaurant name",
   "postPhotoSuccess": "Photo added successfully",
   "postCameraPermission": "Camera permission is required",
   "postAlbumPermission": "Photo library permission is required",
@@ -466,5 +469,6 @@
   "searchEmptyTitle": "Enter restaurant name to search",
   "searchEmptyHintTitle": "Search Tips",
   "searchEmptyHintLocation": "Turn on location to show nearby results first",
-  "searchEmptyHintSearch": "Search by restaurant name or cuisine type"
+  "searchEmptyHintSearch": "Search by restaurant name or cuisine type",
+  "postErrorPickImage": "Failed to take photo"
 }

--- a/assets/l10n/app_ja.arb
+++ b/assets/l10n/app_ja.arb
@@ -54,6 +54,9 @@
   "postCuisineCategory": "料理",
   "postTitle":"投稿",
   "postMissingInfo": "必須項目を入力してください",
+  "postMissingPhoto": "写真を追加してください",
+  "postMissingFoodName": "食べたものを入力してください",
+  "postMissingRestaurant": "レストラン名を追加してください",
   "postPhotoSuccess": "写真を追加しました",
   "postCameraPermission": "カメラの許可が必要です",
   "postAlbumPermission": "フォトライブラリの許可が必要です",
@@ -466,5 +469,6 @@
   "searchEmptyTitle": "店舗名を入力して検索してください",
   "searchEmptyHintTitle": "検索のヒント",
   "searchEmptyHintLocation": "位置情報をオンにすると近い順で表示します",
-  "searchEmptyHintSearch": "店舗名や料理ジャンルで検索できます"
+  "searchEmptyHintSearch": "店舗名や料理ジャンルで検索できます",
+  "postErrorPickImage": "写真ができませんでした"
 }

--- a/lib/gen/l10n/l10n.dart
+++ b/lib/gen/l10n/l10n.dart
@@ -426,6 +426,24 @@ abstract class L10n {
   /// **'必須項目を入力してください'**
   String get postMissingInfo;
 
+  /// No description provided for @postMissingPhoto.
+  ///
+  /// In ja, this message translates to:
+  /// **'写真を追加してください'**
+  String get postMissingPhoto;
+
+  /// No description provided for @postMissingFoodName.
+  ///
+  /// In ja, this message translates to:
+  /// **'食べたものを入力してください'**
+  String get postMissingFoodName;
+
+  /// No description provided for @postMissingRestaurant.
+  ///
+  /// In ja, this message translates to:
+  /// **'レストラン名を追加してください'**
+  String get postMissingRestaurant;
+
   /// No description provided for @postPhotoSuccess.
   ///
   /// In ja, this message translates to:
@@ -2897,6 +2915,12 @@ abstract class L10n {
   /// In ja, this message translates to:
   /// **'店舗名や料理ジャンルで検索できます'**
   String get searchEmptyHintSearch;
+
+  /// No description provided for @postErrorPickImage.
+  ///
+  /// In ja, this message translates to:
+  /// **'写真ができませんでした'**
+  String get postErrorPickImage;
 }
 
 class _L10nDelegate extends LocalizationsDelegate<L10n> {

--- a/lib/gen/l10n/l10n_en.dart
+++ b/lib/gen/l10n/l10n_en.dart
@@ -174,6 +174,15 @@ class L10nEn extends L10n {
   String get postMissingInfo => 'Please fill in all required fields';
 
   @override
+  String get postMissingPhoto => 'Please add a photo';
+
+  @override
+  String get postMissingFoodName => 'Please enter what you ate';
+
+  @override
+  String get postMissingRestaurant => 'Please add restaurant name';
+
+  @override
   String get postPhotoSuccess => 'Photo added successfully';
 
   @override
@@ -1408,4 +1417,7 @@ class L10nEn extends L10n {
 
   @override
   String get searchEmptyHintSearch => 'Search by restaurant name or cuisine type';
+
+  @override
+  String get postErrorPickImage => 'Failed to take photo';
 }

--- a/lib/gen/l10n/l10n_ja.dart
+++ b/lib/gen/l10n/l10n_ja.dart
@@ -174,6 +174,15 @@ class L10nJa extends L10n {
   String get postMissingInfo => '必須項目を入力してください';
 
   @override
+  String get postMissingPhoto => '写真を追加してください';
+
+  @override
+  String get postMissingFoodName => '食べたものを入力してください';
+
+  @override
+  String get postMissingRestaurant => 'レストラン名を追加してください';
+
+  @override
   String get postPhotoSuccess => '写真を追加しました';
 
   @override
@@ -1408,4 +1417,7 @@ class L10nJa extends L10n {
 
   @override
   String get searchEmptyHintSearch => '店舗名や料理ジャンルで検索できます';
+
+  @override
+  String get postErrorPickImage => '写真ができませんでした';
 }

--- a/lib/ui/screen/post/post_screen.dart
+++ b/lib/ui/screen/post/post_screen.dart
@@ -301,7 +301,6 @@ class PostScreen extends HookConsumerWidget {
                       final foodTagString = foodTags.value.isEmpty
                           ? ''
                           : foodTags.value.join(',');
-
                       final result =
                           await ref.read(postViewModelProvider().notifier).post(
                                 restaurantTag: countryTag.value,
@@ -310,10 +309,12 @@ class PostScreen extends HookConsumerWidget {
                       if (result) {
                         context.pop(true);
                       } else {
+                        final status =
+                            ref.watch(postViewModelProvider()).status;
                         SnackBarHelper().openErrorSnackBar(
                           context,
                           l10n.postError,
-                          _getLocalizedStatus(context, state.status),
+                          _getLocalizedStatus(context, status),
                         );
                       }
                     },
@@ -348,23 +349,30 @@ class PostScreen extends HookConsumerWidget {
       (e) => e.name == status,
       orElse: () => PostStatus.initial,
     );
+    final l10n = L10n.of(context);
     switch (postStatus) {
-      case PostStatus.missingInfo:
-        return L10n.of(context).postMissingInfo;
+      case PostStatus.errorPickImage:
+        return l10n.postErrorPickImage;
       case PostStatus.error:
-        return L10n.of(context).postError;
+        return l10n.postError;
       case PostStatus.photoSuccess:
-        return L10n.of(context).postPhotoSuccess;
+        return l10n.postPhotoSuccess;
       case PostStatus.cameraPermission:
-        return L10n.of(context).postCameraPermission;
+        return l10n.postCameraPermission;
       case PostStatus.albumPermission:
-        return L10n.of(context).postAlbumPermission;
+        return l10n.postAlbumPermission;
       case PostStatus.success:
-        return L10n.of(context).postSuccess;
+        return l10n.postSuccess;
       case PostStatus.loading:
         return 'Loading...';
+      case PostStatus.missingPhoto:
+        return l10n.postMissingPhoto;
+      case PostStatus.missingFoodName:
+        return l10n.postMissingFoodName;
+      case PostStatus.missingRestaurant:
+        return l10n.postMissingRestaurant;
       case PostStatus.initial:
-        return '';
+        return 'Loading...';
     }
   }
 }

--- a/lib/ui/screen/post/post_view_model.dart
+++ b/lib/ui/screen/post/post_view_model.dart
@@ -58,9 +58,8 @@ class PostViewModel extends _$PostViewModel {
     primaryFocus?.unfocus();
     loading.state = true;
     state = state.copyWith(status: PostStatus.loading.name);
-    if (_isPostDataMissing()) {
+    if (_isPostMissing()) {
       loading.state = false;
-      state = state.copyWith(status: PostStatus.missingInfo.name);
       return false;
     }
     await _submitPost(restaurantTag, foodTag);
@@ -122,13 +121,24 @@ class PostViewModel extends _$PostViewModel {
     );
   }
 
-  bool _isPostDataMissing() {
-    return foodController.text.isEmpty ||
-        state.restaurant == defaultRestaurantText ||
-        _uploadImage.isEmpty;
+  bool _isPostMissing() {
+    if (_uploadImage.isEmpty) {
+      state = state.copyWith(status: PostStatus.missingPhoto.name);
+      return true;
+    }
+    if (foodController.text.isEmpty) {
+      state = state.copyWith(status: PostStatus.missingFoodName.name);
+      return true;
+    }
+    if (state.restaurant == defaultRestaurantText) {
+      state = state.copyWith(status: PostStatus.missingRestaurant.name);
+      return true;
+    }
+
+    return false;
   }
 
-  Future<bool> _pickImage(ImageSource source, String errorMessage) async {
+  Future<bool> _pickImage(ImageSource source, String errorPickerImage) async {
     try {
       final image = await _picker.pickImage(
         source: source,
@@ -144,7 +154,7 @@ class PostViewModel extends _$PostViewModel {
       return true;
     } on PlatformException catch (error) {
       logger.e(error.message);
-      state = state.copyWith(status: errorMessage);
+      state = state.copyWith(status: errorPickerImage);
       return false;
     }
   }
@@ -198,7 +208,6 @@ class PostViewModel extends _$PostViewModel {
 }
 
 enum PostStatus {
-  missingInfo,
   error,
   photoSuccess,
   cameraPermission,
@@ -206,4 +215,8 @@ enum PostStatus {
   success,
   loading,
   initial,
+  errorPickImage,
+  missingPhoto,
+  missingFoodName,
+  missingRestaurant,
 }


### PR DESCRIPTION
## Issue

- close #751 

## 概要

- 投稿のエラー表示の出し分けを正しくする

## 追加したPackage

- なし
 
## Screenshot

| TH | TH | TH |
| ---- | ---- |---- |
| <img width="750" height="1334" alt="IMG_9768" src="https://github.com/user-attachments/assets/a174f04a-dbf6-458e-81d2-ebc59b4d61f6" /> | <img width="750" height="1334" alt="IMG_9769" src="https://github.com/user-attachments/assets/c9ed3d8f-16ea-4d91-8bde-7aa88bca8214" /> | <img width="750" height="1334" alt="IMG_9770" src="https://github.com/user-attachments/assets/7cfb6694-516f-4266-a7f0-b8af50bf174f" /> |









## 備考

