### PR TITLE
 Kakao APIを利用したレストラン検索機能を実装し、韓国のレストランもヒットするようにしてみました

### DIFF
--- a/lib/core/api/restaurant/repository/kakao_restaurant_repository.dart
+++ b/lib/core/api/restaurant/repository/kakao_restaurant_repository.dart
@@ -1,0 +1,54 @@
+import 'dart:core';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:food_gram_app/core/api/restaurant/services/kakao_restaurant_service.dart';
+import 'package:food_gram_app/core/model/restaurant.dart';
+import 'package:food_gram_app/core/utils/geo_distance.dart';
+import 'package:food_gram_app/core/utils/provider/location.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'kakao_restaurant_repository.g.dart';
+
+typedef PaginationList<T> = List<T>;
+
+@riverpod
+Future<PaginationList<Restaurant>> kakaoRestaurantRepository(
+  Ref ref,
+  String keyword,
+) async {
+  if (keyword.isEmpty) {
+    return [];
+  }
+  try {
+    final currentLocationFuture = ref.read(locationProvider.future);
+    final currentLocation = await currentLocationFuture;
+    final restaurants = <Restaurant>[];
+    final addedLocations = <String>{};
+    final kakao =
+        await ref.read(kakaoRestaurantServicesProvider(keyword).future);
+    void addUniqueRestaurants(List<Restaurant> source) {
+      for (final restaurant in source) {
+        final locationKey = '${restaurant.lat},${restaurant.lng}';
+        if (!addedLocations.contains(locationKey)) {
+          addedLocations.add(locationKey);
+          restaurants.add(restaurant);
+        }
+      }
+    }
+
+    addUniqueRestaurants(kakao);
+    restaurants.sort((a, b) {
+      final lat1 = currentLocation.latitude;
+      final lon1 = currentLocation.longitude;
+      final distanceA =
+          geoKilometers(lat1: lat1, lon1: lon1, lat2: a.lat, lon2: a.lng);
+      final distanceB =
+          geoKilometers(lat1: lat1, lon1: lon1, lat2: b.lat, lon2: b.lng);
+      return distanceA.compareTo(distanceB);
+    });
+    return restaurants;
+  } on DioException catch (_) {
+    return [];
+  }
+}

--- a/lib/core/api/restaurant/services/kakao_restaurant_service.dart
+++ b/lib/core/api/restaurant/services/kakao_restaurant_service.dart
@@ -1,0 +1,60 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:food_gram_app/core/api/client/dio_client.dart';
+import 'package:food_gram_app/core/model/restaurant.dart';
+import 'package:food_gram_app/env.dart';
+import 'package:logger/logger.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'kakao_restaurant_service.g.dart';
+
+typedef PaginationList<T> = List<T>;
+
+@riverpod
+Future<PaginationList<Restaurant>> kakaoRestaurantServices(
+  Ref ref,
+  String keyword,
+) async {
+  final dio = ref.watch(dioClientProvider);
+  final restaurants = <Restaurant>[];
+  final kakaoRestaurants = await _search(dio, ref, keyword);
+  restaurants.addAll(kakaoRestaurants);
+  return restaurants;
+}
+
+Future<List<Restaurant>> _search(
+  Dio dio,
+  Ref ref,
+  String keyword,
+) async {
+  final logger = Logger();
+  try {
+    final response = await dio.get<Map<String, dynamic>>(
+      'https://dapi.kakao.com/v2/local/search/keyword.json',
+      options: Options(
+        headers: {
+          'Authorization': 'KakaoAK ${Env.kakaoRestApiKey}',
+        },
+      ),
+      queryParameters: {
+        'query': keyword,
+        'size': '15',
+      },
+    );
+    if (response.statusCode == 200) {
+      final data = response.data!;
+      final documents = data['documents'] as List<dynamic>;
+
+      return documents.map(
+        (value) {
+          return Restaurant.fromKakaoJson(value as Map<String, dynamic>);
+        },
+      ).toList();
+    } else {
+      return [];
+    }
+  } on DioException catch (e) {
+    logger.e('Kakao API Error: Status ${e.response?.statusCode}');
+    return [];
+  }
+}

--- a/lib/core/model/restaurant.dart
+++ b/lib/core/model/restaurant.dart
@@ -21,4 +21,13 @@ class Restaurant with _$Restaurant {
       lng: location['lng'] as double,
     );
   }
+
+  factory Restaurant.fromKakaoJson(Map<String, dynamic> json) {
+    return Restaurant(
+      name: json['place_name'] as String,
+      address: json['address_name'] as String,
+      lat: double.parse(json['y'] as String),
+      lng: double.parse(json['x'] as String),
+    );
+  }
 }

--- a/lib/env.dart
+++ b/lib/env.dart
@@ -38,6 +38,8 @@ abstract class Env {
   static final String point = _Env.point;
   @EnviedField(varName: 'POST_LENGTH_POINT', obfuscate: true)
   static final String postLengthPoint = _Env.postLengthPoint;
+  @EnviedField(varName: 'KAKAO_REST_API_KEY', obfuscate: true)
+  static final String kakaoRestApiKey = _Env.kakaoRestApiKey;
 }
 
 @Envied(path: '.env.dev')

--- a/lib/env.dart
+++ b/lib/env.dart
@@ -38,7 +38,7 @@ abstract class Env {
   static final String point = _Env.point;
   @EnviedField(varName: 'POST_LENGTH_POINT', obfuscate: true)
   static final String postLengthPoint = _Env.postLengthPoint;
-  @EnviedField(varName: 'KAKAO_REST_API_KEY', obfuscate: true)
+  @EnviedField(varName: 'KAKAO_REST_API_KEY', obfuscate: true, defaultValue: '')
   static final String kakaoRestApiKey = _Env.kakaoRestApiKey;
 }
 

--- a/lib/ui/screen/restaurant/restaurant_screen.dart
+++ b/lib/ui/screen/restaurant/restaurant_screen.dart
@@ -32,9 +32,10 @@ class RestaurantScreen extends HookConsumerWidget {
               isKakao.value = !isKakao.value;
             },
             child: Text(
-              'Kakao検索：${isKakao.value ? 'ON' : 'OFF'}',
-              style:
-                  TextStyle(color: isKakao.value ? Colors.blue : Colors.grey),
+              'Kakao検索:${isKakao.value ? 'ON' : 'OFF'}',
+              style: TextStyle(
+                color: isKakao.value ? Colors.blue : Colors.grey,
+              ),
             ),
           ),
         ],

--- a/lib/ui/screen/restaurant/restaurant_screen.dart
+++ b/lib/ui/screen/restaurant/restaurant_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:food_gram_app/core/api/restaurant/repository/kakao_restaurant_repository.dart';
 import 'package:food_gram_app/core/api/restaurant/repository/restaurant_repository.dart';
 import 'package:food_gram_app/core/model/restaurant.dart';
 import 'package:food_gram_app/core/theme/style/restaurant_style.dart';
@@ -17,11 +18,26 @@ class RestaurantScreen extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final keyword = useState('');
+    final isKakao = useState(false);
     final restaurant = ref.watch(restaurantRepositoryProvider(keyword.value));
+    final kakaoRestaurant =
+        ref.watch(kakaoRestaurantRepositoryProvider(keyword.value));
     return Scaffold(
       appBar: AppBar(
         surfaceTintColor: Colors.white,
         backgroundColor: Colors.white,
+        actions: [
+          TextButton(
+            onPressed: () {
+              isKakao.value = !isKakao.value;
+            },
+            child: Text(
+              'Kakao検索：${isKakao.value ? 'ON' : 'OFF'}',
+              style:
+                  TextStyle(color: isKakao.value ? Colors.blue : Colors.grey),
+            ),
+          ),
+        ],
         leading: IconButton(
           onPressed: context.pop,
           icon: const Icon(
@@ -67,10 +83,13 @@ class RestaurantScreen extends HookConsumerWidget {
               child: keyword.value.isEmpty
                   ? const AppSearchEmpty()
                   : AsyncValueSwitcher(
-                      asyncValue: restaurant,
+                      asyncValue: isKakao.value ? kakaoRestaurant : restaurant,
                       onErrorTap: () {
                         ref.invalidate(
                           restaurantRepositoryProvider(keyword.value),
+                        );
+                        ref.invalidate(
+                          kakaoRestaurantRepositoryProvider(keyword.value),
                         );
                       },
                       onData: (value) {


### PR DESCRIPTION
## Issue

- close #793 

## 概要

-  Kakao APIを利用したレストラン検索機能を実装し、韓国のレストランもヒットするようにしてみました

## 追加したPackage

- なし

## Screenshot

| TH | TH |
| ---- | ---- |
| <img width="750" height="1334" alt="IMG_9828" src="https://github.com/user-attachments/assets/6c96d8c8-8209-402a-9a5e-670ab337091c" /> | <img width="750" height="1334" alt="IMG_9829" src="https://github.com/user-attachments/assets/13db300d-ee25-428a-b0fa-e1a42837e645" />
 |





## 備考
友人にリリースしたものを触ってもらってほんとにできているかを見る必要がありそう


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kakao-based restaurant search added with an ON/OFF toggle in the Restaurant screen.
  * Results are deduplicated by location and sorted by distance from your current position.
  * Empty search keywords now return no results to reduce noise.

* **Bug Fixes / Reliability**
  * Improved error handling so data sources are refreshed on failures for quicker retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->