### PR TITLE
ユーザー検索画面において複数画像の対応をする

### DIFF
--- a/lib/core/supabase/user/services/user_service.dart
+++ b/lib/core/supabase/user/services/user_service.dart
@@ -112,7 +112,7 @@ class UserService extends _$UserService {
       fetcher: () async {
         final postsResponse = await supabase
             .from('posts')
-            .select('user_id, food_image, created_at')
+            .select('id, user_id, food_image, created_at')
             .eq('is_anonymous', false)
             .order('created_at', ascending: false)
             .limit(2500);
@@ -130,6 +130,7 @@ class UserService extends _$UserService {
           }
           if (userLatestPosts[userId]!.length < 4) {
             userLatestPosts[userId]!.add({
+              'id': post['id'],
               'food_image': post['food_image'] ?? '',
               'created_at': post['created_at'],
             });


### PR DESCRIPTION
## Issue

- close #911 
- close #912

## 概要

- ユーザー検索画面において複数画像の対応をする

## 追加したPackage

-　なし

## Screenshot

| Before | After |
| ---- | ---- |
| <img width="585" height="1266" alt="スクリーンショット 2026-01-06 午後2 04 06" src="https://github.com/user-attachments/assets/d25c5d3f-b24c-4d0b-97a0-eeed33f336a3" /> | <img width="585" height="1266" alt="IMG_5437" src="https://github.com/user-attachments/assets/8142bddc-53fc-4c46-9810-64736d7932d6" /> |



## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results now show a circular badge on images when multiple photos are available.
  * Tapping an image opens the post detail view; failures display a brief error notification.

* **Bug Fixes / Improvements**
  * Missing or empty images render a neutral placeholder with a missing-image icon.
  * Latest-post entries now include post identifiers to support reliable navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->