### PR TITLE
投稿画面のパフォーマンス改善

### DIFF
--- a/lib/ui/screen/edit_post/edit_post_screen.dart
+++ b/lib/ui/screen/edit_post/edit_post_screen.dart
@@ -35,11 +35,9 @@ class EditPostScreen extends HookConsumerWidget {
     final l10n = L10n.of(context);
     final deviceWidth = MediaQuery.of(context).size.width;
     final devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
-    // プレビュー用の物理解像度（縮小デコード）
     final previewWidth = (deviceWidth * 0.85 * devicePixelRatio).round();
     final previewHeight = (deviceWidth / 1.7 * devicePixelRatio).round();
     final loading = ref.watch(loadingProvider);
-    // 必要なフィールドのみwatchしてリビルドを最小化
     final status =
         ref.watch(editPostViewModelProvider().select((s) => s.status));
     final existingImagePaths = ref
@@ -240,9 +238,8 @@ class EditPostScreen extends HookConsumerWidget {
                                 final imagePath = foodImages[index];
                                 return Padding(
                                   padding: EdgeInsets.only(
-                                    right: index < foodImages.length - 1
-                                        ? 12
-                                        : 0,
+                                    right:
+                                        index < foodImages.length - 1 ? 12 : 0,
                                   ),
                                   child: Stack(
                                     children: [

--- a/lib/ui/screen/post/post_screen.dart
+++ b/lib/ui/screen/post/post_screen.dart
@@ -34,7 +34,6 @@ class PostScreen extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = L10n.of(context);
     final deviceWidth = MediaQuery.of(context).size.width;
-    // rebuild最小化: 必要なフィールドのみwatch
     final status = ref.watch(postViewModelProvider().select((s) => s.status));
     final foodImages =
         ref.watch(postViewModelProvider().select((s) => s.foodImages));


### PR DESCRIPTION
## Issue

- close #916 

## 概要

- 投稿画面のパフォーマンス改善

## 追加したPackage

- なし

## Screenshot

| TH | TH |
| ---- | ---- |
| <img width="750" height="1334" alt="IMG_0228" src="https://github.com/user-attachments/assets/4e20e870-a68a-4037-969b-ef44878a908d" /> | <img width="750" height="1334" alt="IMG_0229" src="https://github.com/user-attachments/assets/bf485680-c27f-40e3-a78e-28d45fc548a9" /> |



## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized post creation and editing screens to reduce unnecessary UI rebuilds by selectively monitoring specific state fields.
  * Improved image preview sizing and caching (device-pixel-aware) for more consistent loading and layout.
  * Standardized display and toggles for restaurant name and anonymous posting; updated related labels and loading indicators to use granular state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->