### PR TITLE
タイムライン画面の表示速度を少し早くする

### DIFF
--- a/lib/ui/component/common/app_list_view.dart
+++ b/lib/ui/component/common/app_list_view.dart
@@ -40,8 +40,8 @@ class AppListView extends HookConsumerWidget {
     const adEvery = 30;
     final adRowInterval = (adEvery / 3).floor();
     const options = LiveOptions(
-      showItemInterval: Duration(milliseconds: 200),
-      showItemDuration: Duration(milliseconds: 300),
+      showItemInterval: Duration(milliseconds: 150),
+      showItemDuration: Duration(milliseconds: 240),
       visibleFraction: 0.01,
     );
     return LiveSliverList.options(


### PR DESCRIPTION
## Issue

- close #941 941

## 概要

- タイムライン画面の表示速度を少し早くする

## 追加したPackage

- なし

## Screenshot

|Before|After|
|:-:|:-:|
|<video src="https://github.com/user-attachments/assets/6f1148d2-6ef9-444a-b101-a14fa8384f0f">|<video src="https://github.com/user-attachments/assets/64e8eb1c-8585-4c42-85a3-939ac63a3969">|





## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Animation timing for item reveal sequences in list views has been optimized. List items now appear with faster reveal intervals and shorter animation durations, resulting in a more snappy and responsive user experience. The overall interaction cadence is now faster and more fluid, enhancing usability throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->