### PR TITLE
投稿詳細→投稿→レストラン選択を押すとバグる不具合を治す 

### DIFF
--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -191,7 +191,7 @@ final timeLineRouter = GoRoute(
         final model = state.extra! as Restaurant;
         return whiteOut(
           PostScreen(
-            routerPath: RouterPath.timeLineDetailPost,
+            routerPath: RouterPath.timeLineRestaurant,
             restaurant: model,
           ),
         );


### PR DESCRIPTION
## Issue

- close #642 

## 概要

投稿詳細 → 投稿 で開く PostScreen は、ルート timeLineDetailPost で表示されています。
この PostScreen に渡していた routerPath が RouterPath.timeLineDetailPost（自分自身のルート名）のままだったため、「レストラン選択」タップ時に context.pushNamed(routerPath) で 同じ Post 画面のルート を push してしまい、レストラン選択画面に正しく遷移していませんでした。

## 追加したPackage

-　なし

## Screenshot


|Before|After|
|:-:|:-:|
|<video src="https://github.com/user-attachments/assets/ffb394c9-525f-445f-b48a-4a00566d6ff4">|<video src="https://github.com/user-attachments/assets/83d597a3-6b6f-4df2-8cf6-c94829beb5fd">|







## 備考

