### PR TITLE
チュートリアルの権限のボタンの文言を修正しました

### DIFF
--- a/lib/ui/screen/tutorial/tutorial_screen.dart
+++ b/lib/ui/screen/tutorial/tutorial_screen.dart
@@ -136,7 +136,7 @@ class TutorialScreen extends HookConsumerWidget {
                   const Gap(24),
                 ],
               ),
-              // 4ページ目
+              // 4ページ目(位置情報の許可)
               Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
@@ -165,21 +165,11 @@ class TutorialScreen extends HookConsumerWidget {
                       }
                       goToNextPage();
                     },
-                    title: t.tutorial.locationButton,
-                  ),
-                  const Gap(12),
-                  TextButton(
-                    onPressed: goToNextPage,
-                    child: Text(
-                      t.maybeNotFoodDialog.confirm,
-                      style: TextStyle(
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
-                    ),
+                    title: t.maybeNotFoodDialog.confirm,
                   ),
                 ],
               ),
-              // 5ページ目
+              // 5ページ目（通知の許可）
               Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
@@ -205,18 +195,9 @@ class TutorialScreen extends HookConsumerWidget {
                       await initializeNotifications();
                       goToNextPage();
                     },
-                    title: t.tutorial.notificationButton,
+                    title: t.maybeNotFoodDialog.confirm,
                   ),
-                  const Gap(12),
-                  TextButton(
-                    onPressed: goToNextPage,
-                    child: Text(
-                      t.maybeNotFoodDialog.confirm,
-                      style: TextStyle(
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
-                    ),
-                  ),
+              
                 ],
               ),
               // 6ページ目


### PR DESCRIPTION
## Issue

- close #960 

## 概要

- チュートリアルの権限のボタンの文言を修正しました

## 追加したPackage

- なし

## Screenshot

| TH | TH |
| ---- | ---- |
| <img width="750" height="1334" alt="IMG_0312 2" src="https://github.com/user-attachments/assets/2c3518e2-8dd5-4ce1-9363-32c773011348" /> | <img width="750" height="1334" alt="IMG_0313 2" src="https://github.com/user-attachments/assets/b09ce722-04ff-4c2b-9656-a4aea54b865d" /> |


## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined tutorial pages 4 and 5 by removing secondary action buttons, providing a cleaner interface and more focused user onboarding flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->