### PR TITLE
マップのモーダル詳細において、投稿画像の大きさを適切な大きさに調整しました

### DIFF
--- a/lib/ui/component/modal_sheet/app_nearby_restaurants_sheet.dart
+++ b/lib/ui/component/modal_sheet/app_nearby_restaurants_sheet.dart
@@ -572,19 +572,24 @@ class _MapSheetPostListItem extends HookConsumerWidget {
                                   separatorBuilder: (_, __) =>
                                       const SizedBox(width: 8),
                                   itemBuilder: (context, i) {
-                                    return ClipRRect(
-                                      borderRadius: BorderRadius.circular(8),
-                                      child: CachedNetworkImage(
-                                        imageUrl: imageUrls[i],
-                                        height: 90,
-                                        width: 90,
-                                        fit: BoxFit.cover,
-                                        errorWidget: (_, __, ___) =>
-                                            Image.asset(
-                                          isDark
-                                              ? Assets.image.emptyDark.path
-                                              : Assets.image.empty.path,
+                                    const size = 150.0;
+                                    return SizedBox(
+                                      height: size,
+                                      width: size,
+                                      child: ClipRRect(
+                                        borderRadius: BorderRadius.circular(8),
+                                        child: CachedNetworkImage(
+                                          imageUrl: imageUrls[i],
+                                          height: size,
+                                          width: size,
                                           fit: BoxFit.cover,
+                                          errorWidget: (_, __, ___) =>
+                                              Image.asset(
+                                            isDark
+                                                ? Assets.image.emptyDark.path
+                                                : Assets.image.empty.path,
+                                            fit: BoxFit.cover,
+                                          ),
                                         ),
                                       ),
                                     );


### PR DESCRIPTION
## Issue

- close #976 

## 概要

- マップのモーダル詳細において、投稿画像の大きさを適切な大きさに調整しました

## 追加したPackage

-　なし

## Screenshot

| Before | TH | TH |
| ---- | ---- | ---- |
| <img width="750" height="1334" alt="IMG_0353" src="https://github.com/user-attachments/assets/ea86fbfd-e94f-4a9f-b2d2-f7caf43e8117" /> | <img width="750" height="1334" alt="IMG_0354" src="https://github.com/user-attachments/assets/ee65fb51-bbb2-4ee9-983c-6fbaa5b29256" /> |　<img width="750" height="1334" alt="IMG_0355" src="https://github.com/user-attachments/assets/4e14069e-6769-4152-bf1b-92de44457048" /> |







## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enlarged restaurant image tiles in the nearby restaurants modal for improved visibility and consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->