### PR TITLE
投稿詳細画面でスクロールするとAppBarが灰色になるのを白にしました

### DIFF
--- a/lib/ui/screen/post_detail/post_detail_screen.dart
+++ b/lib/ui/screen/post_detail/post_detail_screen.dart
@@ -83,10 +83,10 @@ class PostDetailScreen extends HookConsumerWidget {
           automaticallyImplyLeading: !(loading || isInitialLoading),
           backgroundColor: Theme.of(context).brightness == Brightness.light
               ? Colors.white
-              : Theme.of(context).colorScheme.surfaceTint,
+              : Theme.of(context).colorScheme.surface,
           surfaceTintColor: Theme.of(context).brightness == Brightness.light
               ? Colors.white
-              : Theme.of(context).colorScheme.surfaceTint,
+              : Theme.of(context).colorScheme.surface,
           leading: loading || menuLoading.value || isInitialLoading
               ? const SizedBox.shrink()
               : GestureDetector(


### PR DESCRIPTION
## Issue

- close #1040 

## 概要

- 投稿詳細画面でスクロールするとAppBarが灰色になるのを白にしました

## 追加したPackage

- なし

## Screenshot

<img width="550" height="1034" alt="IMG_0461" src="https://github.com/user-attachments/assets/41684461-ced5-4521-860a-e238fcb1ee3e" />



## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the post detail screen app bar to better adapt to light and dark themes for improved contrast and legibility.
  * Ensures consistent app bar background and tint across theme modes (light uses white; dark uses the surface color), improving visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->