### PR TITLE
タイムラインにおいてフードの中にレストラン名をいれてみました

### DIFF
--- a/lib/ui/component/common/app_list_view.dart
+++ b/lib/ui/component/common/app_list_view.dart
@@ -155,7 +155,7 @@ class AppListView extends HookConsumerWidget {
                               child: Container(
                                 color: Colors.black.withValues(alpha: 0.55),
                                 padding: const EdgeInsets.symmetric(
-                                  horizontal: 4,
+                                  horizontal: 8,
                                   vertical: 3,
                                 ),
                                 child: Text(


### PR DESCRIPTION
## Issue

- close #1043 

## 概要

- タイムラインにおいてフードの中にレストラン名をいれてみました

## 追加したPackage

- なし

## Screenshot

| TH | TH |
| ---- | ---- |
| <img width="750" height="1334" alt="IMG_0463" src="https://github.com/user-attachments/assets/083df250-4f63-4327-a030-c35da0ab4046" /> | <img width="750" height="1334" alt="IMG_0464" src="https://github.com/user-attachments/assets/5bd25cfa-c165-41f8-8cf1-e7ab1ffddb04" /> |



## 備考






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restaurant names now appear as a bottom overlay on grid items when available. The overlay spans the full width, uses a semi‑transparent black background with padding, and shows a single‑line, centered white bold label with ellipsis for long names. It doesn’t interfere with item taps or existing image/icon behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->