### PR TITLE
古い画像の投稿も表示できるように修正してみました

### DIFF
--- a/lib/core/model/posts.dart
+++ b/lib/core/model/posts.dart
@@ -121,7 +121,13 @@ String? _legacyUidFromUuidThenLocalPath(String normalized) {
     return null;
   }
   final uuidRe = RegExp(
-    r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$',
+    '^'
+    '[0-9a-fA-F]{8}-'
+    '[0-9a-fA-F]{4}-'
+    '[0-9a-fA-F]{4}-'
+    '[0-9a-fA-F]{4}-'
+    '[0-9a-fA-F]{12}'
+    r'$',
   );
   if (!uuidRe.hasMatch(prefix)) {
     return null;
@@ -141,15 +147,15 @@ String resolveFoodImagePathForDisplay(String normalized, String postUserId) {
   if (fromPublicUrl != null && fromPublicUrl.isNotEmpty) {
     return _stripFoodBucketPrefixIfPresent(fromPublicUrl);
   }
-  var key = _stripFoodBucketPrefixIfPresent(normalized);
+  final key = _stripFoodBucketPrefixIfPresent(normalized);
 
   // 旧データの中には、Storage にもローカル一時パスを含んだまま
   // （例: `uid//private/var/mobile/.../tmp/image_cropper_....jpg`）
   // 保存されているものがあります。
   // この場合は「uid/filename へ縮退」しないで、Storage 側のキーと一致させる必要があります。
   final legacyUuidThenDoubleSlashLocalPath = RegExp(
-    r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}//'
-    r'(private/var/mobile/Containers/Data/Application|private/var/|var/mobile/|containers/data|data/application|data/user/0/)',
+    '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}//'
+    '(private/var/mobile/Containers/Data/Application|private/var/|var/mobile/|containers/data|data/application|data/user/0/)',
   );
   if (legacyUuidThenDoubleSlashLocalPath.hasMatch(key)) {
     return key;


### PR DESCRIPTION
## Issue

- close #1049 

## 概要

- 古い画像の投稿も表示できるように修正してみました

## 追加したPackage

-　なし

## Screenshot

| Before | After |
| ---- | ---- |
| <img width="750" height="1334" alt="IMG_0486" src="https://github.com/user-attachments/assets/cf9a482d-bb9c-4ea4-8029-766a87ed2c70" /> | <img width="750" height="1334" alt="IMG_0487" src="https://github.com/user-attachments/assets/ab3657e2-ab6e-4c37-aba2-75a436e8648b" /> |


## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Added support for additional image file formats (.heic, .gif).
* Enhanced compatibility with legacy image paths from cloud storage.
* Improved image handling for historical data with legacy storage patterns.
* Updated user attribution to correctly leverage historical metadata in legacy records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->