### PR TITLE
翻訳ができなかった時にSnack Barを出すようにしました

### DIFF
--- a/lib/ui/component/app_translatable_text.dart
+++ b/lib/ui/component/app_translatable_text.dart
@@ -109,6 +109,13 @@ class _TranslatableTextState extends ConsumerState<AppTranslatableText> {
       targetLocale: locale,
     );
     if (!need) {
+      if (!mounted) {
+        return;
+      }
+      final t = Translations.of(context);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(t.translatable.translateFailed)),
+      );
       return;
     }
     setState(() => _isTranslating = true);


### PR DESCRIPTION
## Issue

- close #1062 

## 概要

- 翻訳ができなかった時にSnack Barを出すようにしました

## 追加したPackage

-　なし

## Screenshot


## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for translation—users now receive a notification when translation is unavailable, replacing previous silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->