### PR TITLE
通貨を自分の設定いる言語の通貨に変換できるようにしました

### DIFF
--- a/assets/i18n/strings_de.i18n.json
+++ b/assets/i18n/strings_de.i18n.json
@@ -689,6 +689,9 @@
     "showOriginal": "Original anzeigen",
     "copy": "Kopieren",
     "copied": "In Zwischenablage kopiert",
-    "translateFailed": "Übersetzung fehlgeschlagen"
+    "translateFailed": "Übersetzung fehlgeschlagen",
+    "priceConvertedOriginalSuffix": "(Original: {price})",
+    "priceAlreadyLocalCurrency": "Bereits in der Anzeigewährung",
+    "priceConversionFailed": "Währungsumrechnung fehlgeschlagen"
   }
 }

--- a/assets/i18n/strings_en.i18n.json
+++ b/assets/i18n/strings_en.i18n.json
@@ -689,6 +689,9 @@
     "showOriginal": "Show original",
     "copy": "Copy",
     "copied": "Copied to clipboard",
-    "translateFailed": "Translation failed"
+    "translateFailed": "Translation failed",
+    "priceConvertedOriginalSuffix": "(original: {price})",
+    "priceAlreadyLocalCurrency": "Already in the display currency",
+    "priceConversionFailed": "Currency conversion failed"
   }
 }

--- a/assets/i18n/strings_es.i18n.json
+++ b/assets/i18n/strings_es.i18n.json
@@ -689,6 +689,9 @@
     "showOriginal": "Mostrar original",
     "copy": "Copiar",
     "copied": "Copiado al portapapeles",
-    "translateFailed": "Error al traducir"
+    "translateFailed": "Error al traducir",
+    "priceConvertedOriginalSuffix": "(original: {price})",
+    "priceAlreadyLocalCurrency": "Ya está en la moneda mostrada",
+    "priceConversionFailed": "Error al convertir la moneda"
   }
 }

--- a/assets/i18n/strings_fr.i18n.json
+++ b/assets/i18n/strings_fr.i18n.json
@@ -689,6 +689,9 @@
     "showOriginal": "Afficher l’original",
     "copy": "Copier",
     "copied": "Copié dans le presse-papiers",
-    "translateFailed": "Échec de la traduction"
+    "translateFailed": "Échec de la traduction",
+    "priceConvertedOriginalSuffix": "(original : {price})",
+    "priceAlreadyLocalCurrency": "Déjà dans la devise affichée",
+    "priceConversionFailed": "Échec de la conversion de devise"
   }
 }

--- a/assets/i18n/strings_ja.i18n.json
+++ b/assets/i18n/strings_ja.i18n.json
@@ -689,6 +689,9 @@
     "showOriginal": "原文を表示",
     "copy": "コピー",
     "copied": "コピーしました",
-    "translateFailed": "翻訳できませんでした"
+    "translateFailed": "翻訳できませんでした",
+    "priceConvertedOriginalSuffix": "（元: {price}）",
+    "priceAlreadyLocalCurrency": "すでに表示通貨と同じです",
+    "priceConversionFailed": "通貨変換に失敗しました"
   }
 }

--- a/assets/i18n/strings_ko.i18n.json
+++ b/assets/i18n/strings_ko.i18n.json
@@ -689,6 +689,9 @@
     "showOriginal": "원문 보기",
     "copy": "복사",
     "copied": "클립보드에 복사됨",
-    "translateFailed": "번역에 실패했습니다"
+    "translateFailed": "번역에 실패했습니다",
+    "priceConvertedOriginalSuffix": "(원래: {price})",
+    "priceAlreadyLocalCurrency": "이미 표시 통화와 같습니다",
+    "priceConversionFailed": "환율 변환에 실패했습니다"
   }
 }

--- a/assets/i18n/strings_pt.i18n.json
+++ b/assets/i18n/strings_pt.i18n.json
@@ -689,6 +689,9 @@
     "showOriginal": "Mostrar original",
     "copy": "Copiar",
     "copied": "Copiado para a área de transferência",
-    "translateFailed": "Falha na tradução"
+    "translateFailed": "Falha na tradução",
+    "priceConvertedOriginalSuffix": "(original: {price})",
+    "priceAlreadyLocalCurrency": "Já está na moeda exibida",
+    "priceConversionFailed": "Falha na conversão de moeda"
   }
 }

--- a/assets/i18n/strings_th.i18n.json
+++ b/assets/i18n/strings_th.i18n.json
@@ -689,6 +689,9 @@
     "showOriginal": "แสดงต้นฉบับ",
     "copy": "คัดลอก",
     "copied": "คัดลอกไปยังคลิปบอร์ดแล้ว",
-    "translateFailed": "ไม่สามารถแปลได้"
+    "translateFailed": "ไม่สามารถแปลได้",
+    "priceConvertedOriginalSuffix": "(ราคาเดิม: {price})",
+    "priceAlreadyLocalCurrency": "ตรงกับสกุลเงินที่แสดงอยู่แล้ว",
+    "priceConversionFailed": "แปลงสกุลเงินไม่สำเร็จ"
   }
 }

--- a/assets/i18n/strings_vi.i18n.json
+++ b/assets/i18n/strings_vi.i18n.json
@@ -689,6 +689,9 @@
     "showOriginal": "Hiển thị bản gốc",
     "copy": "Sao chép",
     "copied": "Đã sao chép vào bộ nhớ tạm",
-    "translateFailed": "Dịch không thành công"
+    "translateFailed": "Dịch không thành công",
+    "priceConvertedOriginalSuffix": "(gốc: {price})",
+    "priceAlreadyLocalCurrency": "Đã trùng với tiền tệ hiển thị",
+    "priceConversionFailed": "Chuyển đổi tiền tệ thất bại"
   }
 }

--- a/assets/i18n/strings_zh.i18n.json
+++ b/assets/i18n/strings_zh.i18n.json
@@ -689,6 +689,9 @@
     "showOriginal": "显示原文",
     "copy": "复制",
     "copied": "已复制到剪贴板",
-    "translateFailed": "翻译失败"
+    "translateFailed": "翻译失败",
+    "priceConvertedOriginalSuffix": "（原价：{price}）",
+    "priceAlreadyLocalCurrency": "已与显示货币相同",
+    "priceConversionFailed": "货币换算失败"
   }
 }

--- a/assets/i18n/strings_zh_TW.i18n.json
+++ b/assets/i18n/strings_zh_TW.i18n.json
@@ -689,6 +689,9 @@
     "showOriginal": "顯示原文",
     "copy": "複製",
     "copied": "已複製到剪貼簿",
-    "translateFailed": "翻譯失敗"
+    "translateFailed": "翻譯失敗",
+    "priceConvertedOriginalSuffix": "（原價：{price}）",
+    "priceAlreadyLocalCurrency": "已與顯示幣別相同",
+    "priceConversionFailed": "幣別換算失敗"
   }
 }

--- a/lib/core/api/currency/repository/currency_conversion_repository.dart
+++ b/lib/core/api/currency/repository/currency_conversion_repository.dart
@@ -1,12 +1,15 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:food_gram_app/core/api/currency/services/currency_rate_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-final currencyConversionRepositoryProvider =
-    Provider<CurrencyConversionRepository>(
-  (ref) => CurrencyConversionRepository(
+part 'currency_conversion_repository.g.dart';
+
+@Riverpod(keepAlive: true)
+CurrencyConversionRepository currencyConversionRepository(Ref ref) {
+  return CurrencyConversionRepository(
     rateService: ref.read(currencyRateServiceProvider),
-  ),
-);
+  );
+}
 
 class CurrencyConversionRepository {
   CurrencyConversionRepository({required CurrencyRateService rateService})

--- a/lib/core/api/currency/repository/currency_conversion_repository.dart
+++ b/lib/core/api/currency/repository/currency_conversion_repository.dart
@@ -26,6 +26,20 @@ class CurrencyConversionRepository {
   }) async {
     final from = _normalizeCurrencyCode(fromCurrency);
     final to = _normalizeCurrencyCode(toCurrency);
+    if (from.isEmpty) {
+      throw ArgumentError.value(
+        fromCurrency,
+        'fromCurrency',
+        'Currency code must not be blank.',
+      );
+    }
+    if (to.isEmpty) {
+      throw ArgumentError.value(
+        toCurrency,
+        'toCurrency',
+        'Currency code must not be blank.',
+      );
+    }
     if (from == to) {
       return amount;
     }
@@ -75,7 +89,10 @@ class CurrencyConversionRepository {
         fromCurrency: fromCurrency,
         toCurrency: toCurrency,
       );
-    } on Exception {
+    } on CurrencyRateException catch (e) {
+      if (!e.shouldTryUsdFallback) {
+        rethrow;
+      }
       if (fromCurrency == 'USD' || toCurrency == 'USD') {
         rethrow;
       }

--- a/lib/core/api/currency/repository/currency_conversion_repository.dart
+++ b/lib/core/api/currency/repository/currency_conversion_repository.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:food_gram_app/core/api/currency/services/currency_rate_service.dart';
+
+final currencyConversionRepositoryProvider =
+    Provider<CurrencyConversionRepository>(
+  (ref) => CurrencyConversionRepository(
+    rateService: ref.read(currencyRateServiceProvider),
+  ),
+);
+
+class CurrencyConversionRepository {
+  CurrencyConversionRepository({required CurrencyRateService rateService})
+      : _rateService = rateService;
+
+  final CurrencyRateService _rateService;
+  final Map<String, _RateCacheEntry> _rateCache = <String, _RateCacheEntry>{};
+  static const Duration _cacheTtl = Duration(hours: 6);
+
+  Future<double> convert({
+    required double amount,
+    required String fromCurrency,
+    required String toCurrency,
+  }) async {
+    final from = fromCurrency.toUpperCase();
+    final to = toCurrency.toUpperCase();
+    if (from == to) {
+      return amount;
+    }
+    final rate = await _getRate(from: from, to: to);
+    return amount * rate;
+  }
+
+  Future<double> _getRate({
+    required String from,
+    required String to,
+  }) async {
+    final key = '$from->$to';
+    final cached = _rateCache[key];
+    if (cached != null &&
+        DateTime.now().difference(cached.fetchedAt) <= _cacheTtl) {
+      return cached.rate;
+    }
+
+    final rate = await _rateService.fetchRate(
+      fromCurrency: from,
+      toCurrency: to,
+    );
+    _rateCache[key] = _RateCacheEntry(
+      rate: rate,
+      fetchedAt: DateTime.now(),
+    );
+    return rate;
+  }
+}
+
+class _RateCacheEntry {
+  const _RateCacheEntry({
+    required this.rate,
+    required this.fetchedAt,
+  });
+
+  final double rate;
+  final DateTime fetchedAt;
+}

--- a/lib/core/api/currency/repository/currency_conversion_repository.dart
+++ b/lib/core/api/currency/repository/currency_conversion_repository.dart
@@ -21,13 +21,24 @@ class CurrencyConversionRepository {
     required String fromCurrency,
     required String toCurrency,
   }) async {
-    final from = fromCurrency.toUpperCase();
-    final to = toCurrency.toUpperCase();
+    final from = _normalizeCurrencyCode(fromCurrency);
+    final to = _normalizeCurrencyCode(toCurrency);
     if (from == to) {
       return amount;
     }
     final rate = await _getRate(from: from, to: to);
     return amount * rate;
+  }
+
+  String _normalizeCurrencyCode(String raw) {
+    final code = raw.trim().toUpperCase();
+    switch (code) {
+      case r'NT$':
+      case 'NTD':
+        return 'TWD';
+      default:
+        return code;
+    }
   }
 
   Future<double> _getRate({
@@ -41,7 +52,7 @@ class CurrencyConversionRepository {
       return cached.rate;
     }
 
-    final rate = await _rateService.fetchRate(
+    final rate = await _fetchRateWithFallback(
       fromCurrency: from,
       toCurrency: to,
     );
@@ -50,6 +61,31 @@ class CurrencyConversionRepository {
       fetchedAt: DateTime.now(),
     );
     return rate;
+  }
+
+  Future<double> _fetchRateWithFallback({
+    required String fromCurrency,
+    required String toCurrency,
+  }) async {
+    try {
+      return await _rateService.fetchRate(
+        fromCurrency: fromCurrency,
+        toCurrency: toCurrency,
+      );
+    } on Exception {
+      if (fromCurrency == 'USD' || toCurrency == 'USD') {
+        rethrow;
+      }
+      final toUsd = await _rateService.fetchRate(
+        fromCurrency: fromCurrency,
+        toCurrency: 'USD',
+      );
+      final usdToTarget = await _rateService.fetchRate(
+        fromCurrency: 'USD',
+        toCurrency: toCurrency,
+      );
+      return toUsd * usdToTarget;
+    }
   }
 }
 

--- a/lib/core/api/currency/services/currency_rate_service.dart
+++ b/lib/core/api/currency/services/currency_rate_service.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:food_gram_app/core/supabase/current_user_provider.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+final currencyRateServiceProvider = Provider<CurrencyRateService>(
+  (ref) => CurrencyRateService(supabase: ref.read(supabaseProvider)),
+);
+
+class CurrencyRateService {
+  CurrencyRateService({required SupabaseClient supabase})
+      : _supabase = supabase;
+
+  final SupabaseClient _supabase;
+  static const String _functionName = 'currency-convert';
+
+  Future<double> fetchRate({
+    required String fromCurrency,
+    required String toCurrency,
+  }) async {
+    final from = fromCurrency.toUpperCase();
+    final to = toCurrency.toUpperCase();
+
+    final FunctionResponse res;
+    try {
+      res = await _supabase.functions.invoke(
+        _functionName,
+        body: <String, dynamic>{
+          'from': from,
+          'to': to,
+          'base': from,
+          'symbols': [to],
+          'quotes': [to],
+          'target': to,
+        },
+      );
+    } on FunctionException catch (e) {
+      throw Exception(
+        'Edge Function invoke failed: ${e.details ?? e.toString()}',
+      );
+    }
+
+    final data = res.data;
+    if (data is! Map<String, dynamic>) {
+      throw Exception('Invalid Edge Function response');
+    }
+    if (data['success'] == false) {
+      final error = data['error']?.toString() ?? 'Unknown error';
+      throw Exception('Edge Function error: $error');
+    }
+
+    final parsedRate = _extractRate(data: data, to: to);
+    if (parsedRate != null) {
+      return parsedRate;
+    }
+    throw Exception('Rate not found in Edge Function response');
+  }
+
+  double? _extractRate({
+    required Map<String, dynamic> data,
+    required String to,
+  }) {
+    final directRate = data['rate'];
+    if (directRate is num && directRate > 0) {
+      return directRate.toDouble();
+    }
+
+    final result = data['result'];
+    if (result is num && result > 0) {
+      return result.toDouble();
+    }
+
+    final rates = data['rates'];
+    if (rates is Map) {
+      final dynamic rate = rates[to];
+      if (rate is num && rate > 0) {
+        return rate.toDouble();
+      }
+    }
+
+    final nestedData = data['data'];
+    if (nestedData is Map<String, dynamic>) {
+      return _extractRate(data: nestedData, to: to);
+    }
+    return null;
+  }
+}

--- a/lib/core/api/currency/services/currency_rate_service.dart
+++ b/lib/core/api/currency/services/currency_rate_service.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:food_gram_app/core/supabase/current_user_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -16,6 +18,7 @@ class CurrencyRateService {
 
   final SupabaseClient _supabase;
   static const String _functionName = 'currency-convert';
+  static const Duration _invokeTimeout = Duration(seconds: 12);
 
   Future<double> fetchRate({
     required String fromCurrency,
@@ -36,7 +39,7 @@ class CurrencyRateService {
           'quotes': [to],
           'target': to,
         },
-      );
+      ).timeout(_invokeTimeout);
     } on FunctionException catch (e) {
       throw Exception(
         'Edge Function invoke failed: ${e.details ?? e.toString()}',

--- a/lib/core/api/currency/services/currency_rate_service.dart
+++ b/lib/core/api/currency/services/currency_rate_service.dart
@@ -17,8 +17,8 @@ class CurrencyRateService {
     required String fromCurrency,
     required String toCurrency,
   }) async {
-    final from = fromCurrency.toUpperCase();
-    final to = toCurrency.toUpperCase();
+    final from = fromCurrency.trim().toUpperCase();
+    final to = toCurrency.trim().toUpperCase();
 
     final FunctionResponse res;
     try {

--- a/lib/core/api/currency/services/currency_rate_service.dart
+++ b/lib/core/api/currency/services/currency_rate_service.dart
@@ -40,26 +40,54 @@ class CurrencyRateService {
           'target': to,
         },
       ).timeout(_invokeTimeout);
+    } on TimeoutException catch (e, st) {
+      throw CurrencyRateException(
+        type: CurrencyRateFailureType.timeout,
+        message: 'Edge Function invoke timed out.',
+        cause: e,
+        stackTrace: st,
+      );
     } on FunctionException catch (e) {
-      throw Exception(
-        'Edge Function invoke failed: ${e.details ?? e.toString()}',
+      throw CurrencyRateException(
+        type: CurrencyRateFailureType.invokeFailed,
+        message: 'Edge Function invoke failed: ${e.details ?? e.toString()}',
+        cause: e,
       );
     }
 
     final data = res.data;
     if (data is! Map<String, dynamic>) {
-      throw Exception('Invalid Edge Function response');
+      throw const CurrencyRateException(
+        type: CurrencyRateFailureType.invalidResponse,
+        message: 'Invalid Edge Function response.',
+      );
     }
     if (data['success'] == false) {
       final error = data['error']?.toString() ?? 'Unknown error';
-      throw Exception('Edge Function error: $error');
+      throw CurrencyRateException(
+        type: _looksLikePairUnavailable(error)
+            ? CurrencyRateFailureType.directPairUnavailable
+            : CurrencyRateFailureType.backendError,
+        message: 'Edge Function error: $error',
+      );
     }
 
     final parsedRate = _extractRate(data: data, to: to);
     if (parsedRate != null) {
       return parsedRate;
     }
-    throw Exception('Rate not found in Edge Function response');
+    throw const CurrencyRateException(
+      type: CurrencyRateFailureType.rateMissing,
+      message: 'Rate not found in Edge Function response.',
+    );
+  }
+
+  bool _looksLikePairUnavailable(String rawError) {
+    final text = rawError.toLowerCase();
+    return text.contains('no rate') ||
+        text.contains('pair') && text.contains('not found') ||
+        text.contains('unsupported') && text.contains('pair') ||
+        text.contains('cannot convert');
   }
 
   double? _extractRate({
@@ -90,4 +118,34 @@ class CurrencyRateService {
     }
     return null;
   }
+}
+
+enum CurrencyRateFailureType {
+  invokeFailed,
+  timeout,
+  backendError,
+  invalidResponse,
+  rateMissing,
+  directPairUnavailable,
+}
+
+class CurrencyRateException implements Exception {
+  const CurrencyRateException({
+    required this.type,
+    required this.message,
+    this.cause,
+    this.stackTrace,
+  });
+
+  final CurrencyRateFailureType type;
+  final String message;
+  final Object? cause;
+  final StackTrace? stackTrace;
+
+  bool get shouldTryUsdFallback =>
+      type == CurrencyRateFailureType.directPairUnavailable ||
+      type == CurrencyRateFailureType.timeout;
+
+  @override
+  String toString() => 'CurrencyRateException($type): $message';
 }

--- a/lib/core/api/currency/services/currency_rate_service.dart
+++ b/lib/core/api/currency/services/currency_rate_service.dart
@@ -1,10 +1,14 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:food_gram_app/core/supabase/current_user_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-final currencyRateServiceProvider = Provider<CurrencyRateService>(
-  (ref) => CurrencyRateService(supabase: ref.read(supabaseProvider)),
-);
+part 'currency_rate_service.g.dart';
+
+@Riverpod(keepAlive: true)
+CurrencyRateService currencyRateService(Ref ref) {
+  return CurrencyRateService(supabase: ref.read(supabaseProvider));
+}
 
 class CurrencyRateService {
   CurrencyRateService({required SupabaseClient supabase})

--- a/lib/core/utils/format/post_price_formatter.dart
+++ b/lib/core/utils/format/post_price_formatter.dart
@@ -194,20 +194,47 @@ String postPriceCurrencySymbol(String code) {
 
 /// 端末ロケールから初期通貨を推定（換算はしない）
 String defaultPostPriceCurrencyForLocale(Locale locale) {
-  // アプリの言語設定を最優先にする。
-  // 例: 端末地域がUSでも、アプリ言語がjaならJPYを使う。
-  switch (locale.languageCode.toLowerCase()) {
+  final lang = locale.languageCode.toLowerCase();
+  final country = locale.countryCode?.toUpperCase();
+  final hasCountry = country != null && country.isNotEmpty;
+
+  // 言語だけで一意に決まるもの（国コードがあっても同じ）
+  switch (lang) {
     case 'ja':
       return 'JPY';
     case 'ko':
       return 'KRW';
-    case 'zh':
-      return 'CNY';
-    case 'en':
-      return 'USD';
   }
 
-  final country = locale.countryCode?.toUpperCase();
+  // zh は国によって通貨が変わる（zh_TW は TWD、zh_HK は HKD など）
+  if (lang == 'zh') {
+    if (hasCountry) {
+      switch (country) {
+        case 'TW':
+          return 'TWD';
+        case 'HK':
+          return 'HKD';
+        case 'MO':
+          return 'MOP';
+        case 'CN':
+          return 'CNY';
+        default:
+          return 'CNY';
+      }
+    }
+    return 'CNY';
+  }
+
+  // en は国があれば国ベース、なければ USD（en_GB → GBP など）
+  if (lang == 'en' && !hasCountry) {
+    return 'USD';
+  }
+
+  // それ以外の言語で国が無い場合の既定
+  if (!hasCountry) {
+    return 'USD';
+  }
+
   switch (country) {
     case 'JP':
       return 'JPY';
@@ -418,7 +445,7 @@ String defaultPostPriceCurrencyForLocale(Locale locale) {
         'ME',
         'XK',
       };
-      if (country != null && eurCountries.contains(country)) {
+      if (eurCountries.contains(country)) {
         return 'EUR';
       }
       return 'USD';

--- a/lib/core/utils/format/post_price_formatter.dart
+++ b/lib/core/utils/format/post_price_formatter.dart
@@ -194,6 +194,19 @@ String postPriceCurrencySymbol(String code) {
 
 /// 端末ロケールから初期通貨を推定（換算はしない）
 String defaultPostPriceCurrencyForLocale(Locale locale) {
+  // アプリの言語設定を最優先にする。
+  // 例: 端末地域がUSでも、アプリ言語がjaならJPYを使う。
+  switch (locale.languageCode.toLowerCase()) {
+    case 'ja':
+      return 'JPY';
+    case 'ko':
+      return 'KRW';
+    case 'zh':
+      return 'CNY';
+    case 'en':
+      return 'USD';
+  }
+
   final country = locale.countryCode?.toUpperCase();
   switch (country) {
     case 'JP':

--- a/lib/ui/component/app_convertible_price_text.dart
+++ b/lib/ui/component/app_convertible_price_text.dart
@@ -26,9 +26,11 @@ class AppConvertiblePriceText extends ConsumerStatefulWidget {
 class _AppConvertiblePriceTextState
     extends ConsumerState<AppConvertiblePriceText> {
   String? _convertedDisplay;
-  bool _isConverting = false;
   String? _lastAutoConvertKey;
   String? _dependencyLocaleTag;
+
+  /// 無効化すると進行中の変換結果を破棄する（amount / 通貨 / ロケール変更時）
+  Object _conversionValidity = Object();
 
   String get _originalDisplay => formatPostPriceDisplay(
         amount: widget.amount,
@@ -59,6 +61,7 @@ class _AppConvertiblePriceTextState
     if (!mounted) {
       return;
     }
+    _conversionValidity = Object();
     setState(() {
       _convertedDisplay = null;
       _lastAutoConvertKey = null;
@@ -133,13 +136,10 @@ class _AppConvertiblePriceTextState
     required String targetCurrencyOverride,
     required String sourceCurrencyOverride,
   }) async {
-    if (_isConverting) {
-      return;
-    }
     final targetCurrency = targetCurrencyOverride;
     final sourceCurrency = sourceCurrencyOverride;
+    final validity = _conversionValidity;
 
-    setState(() => _isConverting = true);
     try {
       final repository = ref.read(currencyConversionRepositoryProvider);
       final converted = await repository.convert(
@@ -148,6 +148,9 @@ class _AppConvertiblePriceTextState
         toCurrency: targetCurrency,
       );
       if (!mounted) {
+        return;
+      }
+      if (!identical(validity, _conversionValidity)) {
         return;
       }
       setState(() {
@@ -161,14 +164,13 @@ class _AppConvertiblePriceTextState
       if (!mounted) {
         return;
       }
+      if (!identical(validity, _conversionValidity)) {
+        return;
+      }
       final t = Translations.of(context);
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(t.translatable.priceConversionFailed)),
       );
-    } finally {
-      if (mounted) {
-        setState(() => _isConverting = false);
-      }
     }
   }
 }

--- a/lib/ui/component/app_convertible_price_text.dart
+++ b/lib/ui/component/app_convertible_price_text.dart
@@ -1,0 +1,134 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:food_gram_app/core/api/currency/repository/currency_conversion_repository.dart';
+import 'package:food_gram_app/core/utils/format/post_price_formatter.dart';
+
+class AppConvertiblePriceText extends ConsumerStatefulWidget {
+  const AppConvertiblePriceText({
+    required this.amount,
+    required this.currencyCode,
+    required this.style,
+    super.key,
+  });
+
+  final double amount;
+  final String currencyCode;
+  final TextStyle style;
+
+  @override
+  ConsumerState<AppConvertiblePriceText> createState() =>
+      _AppConvertiblePriceTextState();
+}
+
+class _AppConvertiblePriceTextState
+    extends ConsumerState<AppConvertiblePriceText> {
+  String? _convertedDisplay;
+  bool _isConverting = false;
+  String? _lastAutoConvertKey;
+
+  String get _originalDisplay => formatPostPriceDisplay(
+        amount: widget.amount,
+        currencyCode: widget.currencyCode,
+      );
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    unawaited(_autoConvertIfNeeded());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasConverted = _convertedDisplay != null;
+    final primaryText = hasConverted ? _convertedDisplay! : _originalDisplay;
+    final secondaryText = hasConverted ? '(元: $_originalDisplay)' : null;
+    final secondaryStyle = widget.style.copyWith(
+      fontSize: (widget.style.fontSize ?? 16) * 0.7,
+      fontWeight: FontWeight.w400,
+      color: Theme.of(context).colorScheme.onSurfaceVariant,
+    );
+
+    return Text.rich(
+      TextSpan(
+        children: [
+          TextSpan(
+            text: primaryText,
+            style: widget.style,
+          ),
+          if (secondaryText != null)
+            TextSpan(
+              text: ' $secondaryText',
+              style: secondaryStyle,
+            ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _autoConvertIfNeeded() async {
+    final locale = Localizations.localeOf(context);
+    final sourceCurrency = widget.currencyCode.toUpperCase();
+    final targetCurrency = defaultPostPriceCurrencyForLocale(locale);
+    final key = '${widget.amount}|$sourceCurrency|$targetCurrency';
+    if (_lastAutoConvertKey == key) {
+      return;
+    }
+    _lastAutoConvertKey = key;
+    if (targetCurrency == sourceCurrency) {
+      return;
+    }
+    await _handleConvert(targetCurrencyOverride: targetCurrency);
+  }
+
+  Future<void> _handleConvert({String? targetCurrencyOverride}) async {
+    if (_isConverting) {
+      return;
+    }
+    final locale = Localizations.localeOf(context);
+    final targetCurrency =
+        targetCurrencyOverride ?? defaultPostPriceCurrencyForLocale(locale);
+    final sourceCurrency = widget.currencyCode.toUpperCase();
+
+    if (targetCurrency == sourceCurrency) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('すでにローカル通貨です')),
+      );
+      return;
+    }
+
+    setState(() => _isConverting = true);
+    try {
+      final repository = ref.read(currencyConversionRepositoryProvider);
+      final converted = await repository.convert(
+        amount: widget.amount,
+        fromCurrency: sourceCurrency,
+        toCurrency: targetCurrency,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _convertedDisplay = formatPostPriceDisplay(
+          amount: converted,
+          currencyCode: targetCurrency,
+        );
+      });
+    } on Exception catch (e) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('通貨変換に失敗しました: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isConverting = false);
+      }
+    }
+  }
+}

--- a/lib/ui/component/app_convertible_price_text.dart
+++ b/lib/ui/component/app_convertible_price_text.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:food_gram_app/core/api/currency/repository/currency_conversion_repository.dart';
 import 'package:food_gram_app/core/utils/format/post_price_formatter.dart';
+import 'package:food_gram_app/gen/strings.g.dart';
 
 class AppConvertiblePriceText extends ConsumerStatefulWidget {
   const AppConvertiblePriceText({
@@ -27,23 +28,57 @@ class _AppConvertiblePriceTextState
   String? _convertedDisplay;
   bool _isConverting = false;
   String? _lastAutoConvertKey;
+  String? _dependencyLocaleTag;
 
   String get _originalDisplay => formatPostPriceDisplay(
         amount: widget.amount,
-        currencyCode: widget.currencyCode,
+        currencyCode: widget.currencyCode.trim(),
       );
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    unawaited(_autoConvertIfNeeded());
+    final locale = Localizations.localeOf(context);
+    final tag = locale.toLanguageTag();
+    if (_dependencyLocaleTag != tag) {
+      _dependencyLocaleTag = tag;
+      _clearAndScheduleConvert();
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant AppConvertiblePriceText oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.amount != widget.amount ||
+        oldWidget.currencyCode != widget.currencyCode) {
+      _clearAndScheduleConvert();
+    }
+  }
+
+  void _clearAndScheduleConvert() {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _convertedDisplay = null;
+      _lastAutoConvertKey = null;
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        unawaited(_autoConvertIfNeeded());
+      }
+    });
   }
 
   @override
   Widget build(BuildContext context) {
+    final t = Translations.of(context);
     final hasConverted = _convertedDisplay != null;
     final primaryText = hasConverted ? _convertedDisplay! : _originalDisplay;
-    final secondaryText = hasConverted ? '(元: $_originalDisplay)' : null;
+    final secondaryText = hasConverted
+        ? t.translatable.priceConvertedOriginalSuffix
+            .replaceAll('{price}', _originalDisplay)
+        : null;
     final secondaryStyle = widget.style.copyWith(
       fontSize: (widget.style.fontSize ?? 16) * 0.7,
       fontWeight: FontWeight.w400,
@@ -69,37 +104,40 @@ class _AppConvertiblePriceTextState
 
   Future<void> _autoConvertIfNeeded() async {
     final locale = Localizations.localeOf(context);
-    final sourceCurrency = widget.currencyCode.toUpperCase();
+    final sourceCurrency = widget.currencyCode.trim().toUpperCase();
     final targetCurrency = defaultPostPriceCurrencyForLocale(locale);
-    final key = '${widget.amount}|$sourceCurrency|$targetCurrency';
+    final key = '${locale.toLanguageTag()}'
+        '|${widget.amount}'
+        '|$sourceCurrency'
+        '|$targetCurrency';
+
     if (_lastAutoConvertKey == key) {
       return;
     }
     _lastAutoConvertKey = key;
+
     if (targetCurrency == sourceCurrency) {
+      if (_convertedDisplay != null && mounted) {
+        setState(() => _convertedDisplay = null);
+      }
       return;
     }
-    await _handleConvert(targetCurrencyOverride: targetCurrency);
+
+    await _handleConvert(
+      targetCurrencyOverride: targetCurrency,
+      sourceCurrencyOverride: sourceCurrency,
+    );
   }
 
-  Future<void> _handleConvert({String? targetCurrencyOverride}) async {
+  Future<void> _handleConvert({
+    required String targetCurrencyOverride,
+    required String sourceCurrencyOverride,
+  }) async {
     if (_isConverting) {
       return;
     }
-    final locale = Localizations.localeOf(context);
-    final targetCurrency =
-        targetCurrencyOverride ?? defaultPostPriceCurrencyForLocale(locale);
-    final sourceCurrency = widget.currencyCode.toUpperCase();
-
-    if (targetCurrency == sourceCurrency) {
-      if (!mounted) {
-        return;
-      }
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('すでにローカル通貨です')),
-      );
-      return;
-    }
+    final targetCurrency = targetCurrencyOverride;
+    final sourceCurrency = sourceCurrencyOverride;
 
     setState(() => _isConverting = true);
     try {
@@ -118,12 +156,14 @@ class _AppConvertiblePriceTextState
           currencyCode: targetCurrency,
         );
       });
-    } on Exception catch (e) {
+    } on Exception catch (e, st) {
+      debugPrint('AppConvertiblePriceText: convert failed: $e\n$st');
       if (!mounted) {
         return;
       }
+      final t = Translations.of(context);
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('通貨変換に失敗しました: $e')),
+        SnackBar(content: Text(t.translatable.priceConversionFailed)),
       );
     } finally {
       if (mounted) {

--- a/lib/ui/screen/post_detail/component/post_detail_list_item.dart
+++ b/lib/ui/screen/post_detail/component/post_detail_list_item.dart
@@ -14,6 +14,7 @@ import 'package:food_gram_app/core/utils/helpers/snack_bar_helper.dart';
 import 'package:food_gram_app/gen/strings.g.dart';
 import 'package:food_gram_app/router/go_router_extension.dart';
 import 'package:food_gram_app/router/router.dart';
+import 'package:food_gram_app/ui/component/app_convertible_price_text.dart';
 import 'package:food_gram_app/ui/component/app_elevated_button.dart';
 import 'package:food_gram_app/ui/component/app_translatable_text.dart';
 import 'package:food_gram_app/ui/component/dialog/app_share_dialog.dart';
@@ -477,8 +478,9 @@ class PostDetailListItem extends HookConsumerWidget {
                     Row(
                       children: [
                         if (posts.formattedPriceDisplay.isNotEmpty) ...[
-                          Text(
-                            posts.formattedPriceDisplay,
+                          AppConvertiblePriceText(
+                            amount: posts.priceAmount!,
+                            currencyCode: posts.priceCurrency!,
                             style: TextStyle(
                               fontSize: 20,
                               fontWeight: FontWeight.w600,

--- a/lib/ui/screen/post_detail/component/post_detail_list_item.dart
+++ b/lib/ui/screen/post_detail/component/post_detail_list_item.dart
@@ -511,18 +511,18 @@ class PostDetailListItem extends HookConsumerWidget {
                         ],
                       ],
                     ),
-                    const Gap(8),
+                    const Gap(4),
                     if (posts.comment.isNotEmpty)
                       AppTranslatableText(
                         posts.comment,
                         style: DetailPostStyle.comment(context),
                       ),
-                    const Gap(8),
+                    const Gap(4),
                     Text(
                       '${_formatDateTime(posts.createdAt)} ${t.posted}',
                       style: DetailPostStyle.comment(context),
                     ),
-                    const Gap(12),
+                    const Gap(8),
                     Wrap(
                       spacing: 10,
                       children: [


### PR DESCRIPTION
## Issue

- close #1061

## 概要

- 通貨を自分の設定いる言語の通貨に変換できるようにしました

## 追加したPackage

- なし

## Screenshot

| TH | TH | TH | TH |
| ---- | ---- | ---- | ---- |
| <img width="750" height="1334" alt="IMG_0509" src="https://github.com/user-attachments/assets/7a1a0788-2200-4f07-8491-0fd257e3f8cc" /> | <img width="750" height="1334" alt="IMG_0510" src="https://github.com/user-attachments/assets/c98e3181-4fe9-487a-a02c-0dc27592d489" /> | <img width="750" height="1334" alt="IMG_0511" src="https://github.com/user-attachments/assets/525b3f03-4133-4f17-9f7f-3b56c982ad4d" /> | <img width="750" height="1334" alt="IMG_0512" src="https://github.com/user-attachments/assets/0ff25b78-8a16-4d92-876b-7e457bd51ea9" /> |



## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic, locale-aware currency conversion for post prices with optional original-price suffix and user-facing error message.

* **Localization**
  * Added translations for price-conversion UI (original-price suffix, already-local message, conversion-failed) across 11 locales.

* **UI**
  * Replaced static price text with convertible price widget and tightened vertical spacing in post details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->