### PR TITLE
フードの写真の位置情報からレストランを自動で提案できるようにしました

### DIFF
--- a/assets/i18n/strings_de.i18n.json
+++ b/assets/i18n/strings_de.i18n.json
@@ -146,6 +146,7 @@
     "nearbyOpen": "Geöffnet",
     "nearbyClosed": "Geschlossen",
     "nearbyDistanceMeters": "{distance}m",
+    "nearbyDistanceKilometers": "{distance}km",
     "nearbySourceCommunity": "FoodGram"
   },
   "share": {

--- a/assets/i18n/strings_de.i18n.json
+++ b/assets/i18n/strings_de.i18n.json
@@ -132,7 +132,21 @@
     "requiredInfoMissing": "Erforderliche Informationen fehlen",
     "saveDraft": "Entwurf speichern",
     "draftSaved": "Entwurf gespeichert",
-    "draftRestored": "Entwurf geladen"
+    "draftRestored": "Entwurf geladen",
+    "nearbySuggestionTitle": "Restaurant für dieses Foto auswählen",
+    "nearbySuggestionSubtitle": "Gastronomie in der Nähe des Aufnahmeorts",
+    "nearbyCommunityHint": "Andere FoodGram-Nutzer haben hier gepostet",
+    "nearbyMallHint": "Möglicherweise in einem Einkaufszentrum. Bitte prüfen.",
+    "nearbyDistanceHint": "Dieser Ort ist etwas entfernt vom Foto. Bitte prüfen.",
+    "nearbySelect": "Diesen Ort wählen",
+    "nearbyManualSearch": "Manuell suchen",
+    "nearbyPostWithout": "Ohne Restaurant posten",
+    "nearbyEmpty": "Keine Restaurants in der Nähe gefunden",
+    "nearbyFetchError": "Vorschläge konnten nicht geladen werden",
+    "nearbyOpen": "Geöffnet",
+    "nearbyClosed": "Geschlossen",
+    "nearbyDistanceMeters": "{distance}m",
+    "nearbySourceCommunity": "FoodGram"
   },
   "share": {
     "shareButton": "Teilen",

--- a/assets/i18n/strings_en.i18n.json
+++ b/assets/i18n/strings_en.i18n.json
@@ -146,6 +146,7 @@
     "nearbyOpen": "Open now",
     "nearbyClosed": "Closed",
     "nearbyDistanceMeters": "{distance}m",
+    "nearbyDistanceKilometers": "{distance}km",
     "nearbySourceCommunity": "FoodGram"
   },
   "share": {

--- a/assets/i18n/strings_en.i18n.json
+++ b/assets/i18n/strings_en.i18n.json
@@ -132,7 +132,21 @@
     "requiredInfoMissing": "Required information is missing",
     "saveDraft": "Save draft",
     "draftSaved": "Draft saved",
-    "draftRestored": "Draft loaded"
+    "draftRestored": "Draft loaded",
+    "nearbySuggestionTitle": "Select the restaurant for this photo",
+    "nearbySuggestionSubtitle": "Showing eateries near where this photo was taken",
+    "nearbyCommunityHint": "Other FoodGram users posted here",
+    "nearbyMallHint": "May be inside a station building or mall. Please verify.",
+    "nearbyDistanceHint": "This place is a bit far from the photo location. Please verify.",
+    "nearbySelect": "Select this place",
+    "nearbyManualSearch": "Search manually",
+    "nearbyPostWithout": "Post without restaurant",
+    "nearbyEmpty": "No nearby restaurants found",
+    "nearbyFetchError": "Failed to load restaurant suggestions",
+    "nearbyOpen": "Open now",
+    "nearbyClosed": "Closed",
+    "nearbyDistanceMeters": "{distance}m",
+    "nearbySourceCommunity": "FoodGram"
   },
   "share": {
     "shareButton": "Share",

--- a/assets/i18n/strings_es.i18n.json
+++ b/assets/i18n/strings_es.i18n.json
@@ -132,7 +132,21 @@
     "requiredInfoMissing": "Falta información requerida",
     "saveDraft": "Guardar borrador",
     "draftSaved": "Borrador guardado",
-    "draftRestored": "Borrador cargado"
+    "draftRestored": "Borrador cargado",
+    "nearbySuggestionTitle": "Selecciona el restaurante de esta foto",
+    "nearbySuggestionSubtitle": "Mostrando lugares cerca de donde se tomó la foto",
+    "nearbyCommunityHint": "Otros usuarios de FoodGram publicaron aquí",
+    "nearbyMallHint": "Puede estar dentro de un centro comercial. Verifica.",
+    "nearbyDistanceHint": "Este lugar está un poco lejos de la foto. Verifica.",
+    "nearbySelect": "Seleccionar este lugar",
+    "nearbyManualSearch": "Buscar manualmente",
+    "nearbyPostWithout": "Publicar sin restaurante",
+    "nearbyEmpty": "No se encontraron restaurantes cercanos",
+    "nearbyFetchError": "No se pudieron cargar las sugerencias",
+    "nearbyOpen": "Abierto",
+    "nearbyClosed": "Cerrado",
+    "nearbyDistanceMeters": "{distance}m",
+    "nearbySourceCommunity": "FoodGram"
   },
   "share": {
     "shareButton": "Compartir",

--- a/assets/i18n/strings_es.i18n.json
+++ b/assets/i18n/strings_es.i18n.json
@@ -146,6 +146,7 @@
     "nearbyOpen": "Abierto",
     "nearbyClosed": "Cerrado",
     "nearbyDistanceMeters": "{distance}m",
+    "nearbyDistanceKilometers": "{distance}km",
     "nearbySourceCommunity": "FoodGram"
   },
   "share": {

--- a/assets/i18n/strings_fr.i18n.json
+++ b/assets/i18n/strings_fr.i18n.json
@@ -146,6 +146,7 @@
     "nearbyOpen": "Ouvert",
     "nearbyClosed": "Fermé",
     "nearbyDistanceMeters": "{distance}m",
+    "nearbyDistanceKilometers": "{distance}km",
     "nearbySourceCommunity": "FoodGram"
   },
   "share": {

--- a/assets/i18n/strings_fr.i18n.json
+++ b/assets/i18n/strings_fr.i18n.json
@@ -132,7 +132,21 @@
     "requiredInfoMissing": "Informations requises manquantes",
     "saveDraft": "Enregistrer le brouillon",
     "draftSaved": "Brouillon enregistré",
-    "draftRestored": "Brouillon chargé"
+    "draftRestored": "Brouillon chargé",
+    "nearbySuggestionTitle": "Choisissez le restaurant de cette photo",
+    "nearbySuggestionSubtitle": "Établissements proches du lieu de la photo",
+    "nearbyCommunityHint": "D'autres utilisateurs FoodGram ont posté ici",
+    "nearbyMallHint": "Peut être dans un centre commercial. Vérifiez.",
+    "nearbyDistanceHint": "Ce lieu est un peu loin de la photo. Vérifiez.",
+    "nearbySelect": "Choisir ce lieu",
+    "nearbyManualSearch": "Rechercher manuellement",
+    "nearbyPostWithout": "Publier sans restaurant",
+    "nearbyEmpty": "Aucun restaurant à proximité",
+    "nearbyFetchError": "Échec du chargement des suggestions",
+    "nearbyOpen": "Ouvert",
+    "nearbyClosed": "Fermé",
+    "nearbyDistanceMeters": "{distance}m",
+    "nearbySourceCommunity": "FoodGram"
   },
   "share": {
     "shareButton": "Partager",

--- a/assets/i18n/strings_ja.i18n.json
+++ b/assets/i18n/strings_ja.i18n.json
@@ -132,7 +132,21 @@
     "requiredInfoMissing": "必要な情報が入力されていません",
     "saveDraft": "下書き保存",
     "draftSaved": "下書きを保存しました",
-    "draftRestored": "下書きを読み込みました"
+    "draftRestored": "下書きを読み込みました",
+    "nearbySuggestionTitle": "この写真のお店を選択してください",
+    "nearbySuggestionSubtitle": "撮影位置の近くの飲食店を表示しています",
+    "nearbyCommunityHint": "この場所で他のユーザーが投稿しています",
+    "nearbyMallHint": "駅ビル・商業施設内の可能性があります。正しいお店かご確認ください",
+    "nearbyDistanceHint": "撮影位置から少し離れたお店です。ご確認ください",
+    "nearbySelect": "このお店を選択",
+    "nearbyManualSearch": "手動で検索",
+    "nearbyPostWithout": "レストランなしで投稿",
+    "nearbyEmpty": "近くにお店が見つかりませんでした",
+    "nearbyFetchError": "お店の候補取得に失敗しました",
+    "nearbyOpen": "営業中",
+    "nearbyClosed": "営業時間外",
+    "nearbyDistanceMeters": "{distance}m",
+    "nearbySourceCommunity": "FoodGram"
   },
   "share": {
     "shareButton": "シェア",

--- a/assets/i18n/strings_ja.i18n.json
+++ b/assets/i18n/strings_ja.i18n.json
@@ -146,6 +146,7 @@
     "nearbyOpen": "営業中",
     "nearbyClosed": "営業時間外",
     "nearbyDistanceMeters": "{distance}m",
+    "nearbyDistanceKilometers": "{distance}km",
     "nearbySourceCommunity": "FoodGram"
   },
   "share": {

--- a/assets/i18n/strings_ko.i18n.json
+++ b/assets/i18n/strings_ko.i18n.json
@@ -132,7 +132,21 @@
     "requiredInfoMissing": "필수 정보가 누락되었습니다",
     "saveDraft": "임시 저장",
     "draftSaved": "임시 저장되었습니다",
-    "draftRestored": "임시 저장을 불러왔습니다"
+    "draftRestored": "임시 저장을 불러왔습니다",
+    "nearbySuggestionTitle": "이 사진의 식당을 선택해 주세요",
+    "nearbySuggestionSubtitle": "촬영 위치 근처의 음식점을 표시합니다",
+    "nearbyCommunityHint": "이 장소에 다른 FoodGram 사용자가 게시했습니다",
+    "nearbyMallHint": "역 건물·상업시설 안일 수 있습니다. 확인해 주세요.",
+    "nearbyDistanceHint": "촬영 위치에서 조금 떨어진 곳입니다. 확인해 주세요.",
+    "nearbySelect": "이 식당 선택",
+    "nearbyManualSearch": "직접 검색",
+    "nearbyPostWithout": "식당 없이 게시",
+    "nearbyEmpty": "근처 식당을 찾지 못했습니다",
+    "nearbyFetchError": "식당 후보를 불러오지 못했습니다",
+    "nearbyOpen": "영업 중",
+    "nearbyClosed": "영업 종료",
+    "nearbyDistanceMeters": "{distance}m",
+    "nearbySourceCommunity": "FoodGram"
   },
   "share": {
     "shareButton": "공유",

--- a/assets/i18n/strings_ko.i18n.json
+++ b/assets/i18n/strings_ko.i18n.json
@@ -146,6 +146,7 @@
     "nearbyOpen": "영업 중",
     "nearbyClosed": "영업 종료",
     "nearbyDistanceMeters": "{distance}m",
+    "nearbyDistanceKilometers": "{distance}km",
     "nearbySourceCommunity": "FoodGram"
   },
   "share": {

--- a/assets/i18n/strings_pt.i18n.json
+++ b/assets/i18n/strings_pt.i18n.json
@@ -132,7 +132,21 @@
     "requiredInfoMissing": "Informações obrigatórias em falta",
     "saveDraft": "Salvar rascunho",
     "draftSaved": "Rascunho salvo",
-    "draftRestored": "Rascunho carregado"
+    "draftRestored": "Rascunho carregado",
+    "nearbySuggestionTitle": "Selecione o restaurante desta foto",
+    "nearbySuggestionSubtitle": "Mostrando locais perto de onde a foto foi tirada",
+    "nearbyCommunityHint": "Outros usuários do FoodGram postaram aqui",
+    "nearbyMallHint": "Pode estar em um shopping. Verifique.",
+    "nearbyDistanceHint": "Este local está um pouco longe da foto. Verifique.",
+    "nearbySelect": "Selecionar este local",
+    "nearbyManualSearch": "Buscar manualmente",
+    "nearbyPostWithout": "Postar sem restaurante",
+    "nearbyEmpty": "Nenhum restaurante próximo encontrado",
+    "nearbyFetchError": "Falha ao carregar sugestões",
+    "nearbyOpen": "Aberto",
+    "nearbyClosed": "Fechado",
+    "nearbyDistanceMeters": "{distance}m",
+    "nearbySourceCommunity": "FoodGram"
   },
   "share": {
     "shareButton": "Compartilhar",

--- a/assets/i18n/strings_pt.i18n.json
+++ b/assets/i18n/strings_pt.i18n.json
@@ -146,6 +146,7 @@
     "nearbyOpen": "Aberto",
     "nearbyClosed": "Fechado",
     "nearbyDistanceMeters": "{distance}m",
+    "nearbyDistanceKilometers": "{distance}km",
     "nearbySourceCommunity": "FoodGram"
   },
   "share": {

--- a/assets/i18n/strings_th.i18n.json
+++ b/assets/i18n/strings_th.i18n.json
@@ -146,6 +146,7 @@
     "nearbyOpen": "เปิดอยู่",
     "nearbyClosed": "ปิดแล้ว",
     "nearbyDistanceMeters": "{distance}m",
+    "nearbyDistanceKilometers": "{distance}km",
     "nearbySourceCommunity": "FoodGram"
   },
   "share": {

--- a/assets/i18n/strings_th.i18n.json
+++ b/assets/i18n/strings_th.i18n.json
@@ -132,7 +132,21 @@
     "requiredInfoMissing": "ข้อมูลที่จำเป็นขาดหายไป",
     "saveDraft": "บันทึกแบบร่าง",
     "draftSaved": "บันทึกแบบร่างแล้ว",
-    "draftRestored": "โหลดแบบร่างแล้ว"
+    "draftRestored": "โหลดแบบร่างแล้ว",
+    "nearbySuggestionTitle": "เลือกร้านอาหารสำหรับรูปนี้",
+    "nearbySuggestionSubtitle": "แสดงร้านอาหารใกล้จุดที่ถ่ายรูป",
+    "nearbyCommunityHint": "ผู้ใช้ FoodGram คนอื่นโพสต์ที่นี่",
+    "nearbyMallHint": "อาจอยู่ในห้างหรืออาคารสถานี กรุณาตรวจสอบ",
+    "nearbyDistanceHint": "ร้านนี้อยู่ห่างจากจุดถ่ายรูปเล็กน้อย กรุณาตรวจสอบ",
+    "nearbySelect": "เลือกร้านนี้",
+    "nearbyManualSearch": "ค้นหาเอง",
+    "nearbyPostWithout": "โพสต์โดยไม่ระบุร้าน",
+    "nearbyEmpty": "ไม่พบร้านอาหารใกล้เคียง",
+    "nearbyFetchError": "โหลดร้านแนะนำไม่สำเร็จ",
+    "nearbyOpen": "เปิดอยู่",
+    "nearbyClosed": "ปิดแล้ว",
+    "nearbyDistanceMeters": "{distance}m",
+    "nearbySourceCommunity": "FoodGram"
   },
   "share": {
     "shareButton": "แชร์",

--- a/assets/i18n/strings_vi.i18n.json
+++ b/assets/i18n/strings_vi.i18n.json
@@ -146,6 +146,7 @@
     "nearbyOpen": "Đang mở",
     "nearbyClosed": "Đã đóng",
     "nearbyDistanceMeters": "{distance}m",
+    "nearbyDistanceKilometers": "{distance}km",
     "nearbySourceCommunity": "FoodGram"
   },
   "share": {

--- a/assets/i18n/strings_vi.i18n.json
+++ b/assets/i18n/strings_vi.i18n.json
@@ -132,7 +132,21 @@
     "requiredInfoMissing": "Thông tin bắt buộc bị thiếu",
     "saveDraft": "Lưu bản nháp",
     "draftSaved": "Đã lưu bản nháp",
-    "draftRestored": "Đã tải bản nháp"
+    "draftRestored": "Đã tải bản nháp",
+    "nearbySuggestionTitle": "Chọn nhà hàng cho ảnh này",
+    "nearbySuggestionSubtitle": "Hiển thị quán ăn gần vị trí chụp ảnh",
+    "nearbyCommunityHint": "Người dùng FoodGram khác đã đăng tại đây",
+    "nearbyMallHint": "Có thể nằm trong trung tâm thương mại. Vui lòng kiểm tra.",
+    "nearbyDistanceHint": "Địa điểm hơi xa vị trí chụp. Vui lòng kiểm tra.",
+    "nearbySelect": "Chọn địa điểm này",
+    "nearbyManualSearch": "Tìm thủ công",
+    "nearbyPostWithout": "Đăng không cần nhà hàng",
+    "nearbyEmpty": "Không tìm thấy nhà hàng gần đây",
+    "nearbyFetchError": "Không tải được gợi ý nhà hàng",
+    "nearbyOpen": "Đang mở",
+    "nearbyClosed": "Đã đóng",
+    "nearbyDistanceMeters": "{distance}m",
+    "nearbySourceCommunity": "FoodGram"
   },
   "share": {
     "shareButton": "Chia sẻ",

--- a/assets/i18n/strings_zh.i18n.json
+++ b/assets/i18n/strings_zh.i18n.json
@@ -146,6 +146,7 @@
     "nearbyOpen": "营业中",
     "nearbyClosed": "已打烊",
     "nearbyDistanceMeters": "{distance}m",
+    "nearbyDistanceKilometers": "{distance}km",
     "nearbySourceCommunity": "FoodGram"
   },
   "share": {

--- a/assets/i18n/strings_zh.i18n.json
+++ b/assets/i18n/strings_zh.i18n.json
@@ -132,7 +132,21 @@
     "requiredInfoMissing": "缺少必要信息",
     "saveDraft": "保存草稿",
     "draftSaved": "草稿已保存",
-    "draftRestored": "已加载草稿"
+    "draftRestored": "已加载草稿",
+    "nearbySuggestionTitle": "请选择这张照片的餐厅",
+    "nearbySuggestionSubtitle": "显示拍摄位置附近的餐饮店",
+    "nearbyCommunityHint": "有其他 FoodGram 用户在此发布",
+    "nearbyMallHint": "可能在商场或车站大楼内，请确认。",
+    "nearbyDistanceHint": "该店离拍摄位置稍远，请确认。",
+    "nearbySelect": "选择此店",
+    "nearbyManualSearch": "手动搜索",
+    "nearbyPostWithout": "不填餐厅发布",
+    "nearbyEmpty": "附近未找到餐厅",
+    "nearbyFetchError": "获取餐厅候选失败",
+    "nearbyOpen": "营业中",
+    "nearbyClosed": "已打烊",
+    "nearbyDistanceMeters": "{distance}m",
+    "nearbySourceCommunity": "FoodGram"
   },
   "share": {
     "shareButton": "分享",

--- a/assets/i18n/strings_zh_TW.i18n.json
+++ b/assets/i18n/strings_zh_TW.i18n.json
@@ -146,6 +146,7 @@
     "nearbyOpen": "營業中",
     "nearbyClosed": "已打烊",
     "nearbyDistanceMeters": "{distance}m",
+    "nearbyDistanceKilometers": "{distance}km",
     "nearbySourceCommunity": "FoodGram"
   },
   "share": {

--- a/assets/i18n/strings_zh_TW.i18n.json
+++ b/assets/i18n/strings_zh_TW.i18n.json
@@ -132,7 +132,21 @@
     "requiredInfoMissing": "缺少必要資訊",
     "saveDraft": "儲存草稿",
     "draftSaved": "草稿已儲存",
-    "draftRestored": "已載入草稿"
+    "draftRestored": "已載入草稿",
+    "nearbySuggestionTitle": "請選擇這張照片的餐廳",
+    "nearbySuggestionSubtitle": "顯示拍攝位置附近的餐飲店",
+    "nearbyCommunityHint": "有其他 FoodGram 使用者在這裡發布",
+    "nearbyMallHint": "可能在商場或車站大樓內，請確認。",
+    "nearbyDistanceHint": "該店離拍攝位置稍遠，請確認。",
+    "nearbySelect": "選擇此店",
+    "nearbyManualSearch": "手動搜尋",
+    "nearbyPostWithout": "不填餐廳發布",
+    "nearbyEmpty": "附近未找到餐廳",
+    "nearbyFetchError": "取得餐廳候選失敗",
+    "nearbyOpen": "營業中",
+    "nearbyClosed": "已打烊",
+    "nearbyDistanceMeters": "{distance}m",
+    "nearbySourceCommunity": "FoodGram"
   },
   "share": {
     "shareButton": "分享",

--- a/lib/core/api/restaurant/photo_nearby_food_types.dart
+++ b/lib/core/api/restaurant/photo_nearby_food_types.dart
@@ -1,6 +1,4 @@
 /// Google Places Nearby Search で拾う飲食系の type 一覧。
-///
-/// 吉野家などのチェーン店は primary type が [fast_food_restaurant] のため必須。
 const photoNearbyFoodPlaceTypes = [
   'restaurant',
   'fast_food_restaurant',

--- a/lib/core/api/restaurant/photo_nearby_food_types.dart
+++ b/lib/core/api/restaurant/photo_nearby_food_types.dart
@@ -1,0 +1,22 @@
+/// Google Places Nearby Search で拾う飲食系の type 一覧。
+///
+/// 吉野家などのチェーン店は primary type が [fast_food_restaurant] のため必須。
+const photoNearbyFoodPlaceTypes = [
+  'restaurant',
+  'fast_food_restaurant',
+  'japanese_restaurant',
+  'cafe',
+  'bakery',
+  'meal_takeaway',
+  'meal_delivery',
+  'food_court',
+  'ramen_restaurant',
+  'hamburger_restaurant',
+];
+
+/// Text Search フォールバック用クエリ（日本向け）
+const photoNearbyTextSearchQueries = [
+  '飲食店',
+  'レストラン',
+  'ファストフード',
+];

--- a/lib/core/api/restaurant/repository/photo_nearby_restaurant_repository.dart
+++ b/lib/core/api/restaurant/repository/photo_nearby_restaurant_repository.dart
@@ -71,13 +71,18 @@ List<PhotoRestaurantCandidate> _mergeCandidates(
     if (candidate.name.trim().isEmpty) {
       continue;
     }
-    final key =
-        '${candidate.name}_${candidate.lat.toStringAsFixed(4)}_${candidate.lng.toStringAsFixed(4)}';
+    final key = _locationKey(candidate);
     if (seen.add(key)) {
       unique.add(candidate);
     }
   }
   return unique;
+}
+
+String _locationKey(PhotoRestaurantCandidate candidate) {
+  final lat = candidate.lat.toStringAsFixed(4);
+  final lng = candidate.lng.toStringAsFixed(4);
+  return '${candidate.name}_${lat}_$lng';
 }
 
 /// 近い距離帯から優先して最大10件（純粋に距離順）

--- a/lib/core/api/restaurant/repository/photo_nearby_restaurant_repository.dart
+++ b/lib/core/api/restaurant/repository/photo_nearby_restaurant_repository.dart
@@ -89,8 +89,7 @@ List<PhotoRestaurantCandidate> _pickClosest(
 
   for (final maxDist in _displayDistanceTiersMeters) {
     final tier = sorted.where((c) => c.distanceMeters <= maxDist).toList();
-    if (tier.length >= _maxCandidates ||
-        maxDist == _displayDistanceTiersMeters.last) {
+    if (tier.length >= _maxCandidates) {
       return tier.take(_maxCandidates).toList();
     }
   }

--- a/lib/core/api/restaurant/repository/photo_nearby_restaurant_repository.dart
+++ b/lib/core/api/restaurant/repository/photo_nearby_restaurant_repository.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:food_gram_app/core/api/restaurant/services/google_nearby_restaurant_service.dart';
+import 'package:food_gram_app/core/api/restaurant/services/google_photo_text_search_service.dart';
+import 'package:food_gram_app/core/model/photo_restaurant_candidate.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'photo_nearby_restaurant_repository.g.dart';
+
+const _maxCandidates = 10;
+
+/// Nearby Search の検索半径
+const _searchRadiiMeters = [50, 100, 150];
+
+/// 表示する距離の段階（近い順に埋める）
+const _displayDistanceTiersMeters = [30.0, 60.0, 100.0];
+
+/// 写真の撮影位置から近くのレストラン候補を取得する。
+///
+/// - Nearby Search（飲食店 type 網羅・距離順）
+/// - Text Search（日本語クエリ・常に併用）
+/// - 最終的に距離が近い順に最大10件
+@riverpod
+Future<List<PhotoRestaurantCandidate>> photoNearbyRestaurant(
+  Ref ref, {
+  required double latitude,
+  required double longitude,
+}) async {
+  final nearby = await _fetchNearbyCandidates(
+    ref,
+    latitude: latitude,
+    longitude: longitude,
+  );
+
+  final textSearch = await ref.read(
+    googlePhotoTextSearchServiceProvider(
+      latitude: latitude,
+      longitude: longitude,
+    ).future,
+  );
+
+  return _pickClosest(_mergeCandidates([...nearby, ...textSearch]));
+}
+
+Future<List<PhotoRestaurantCandidate>> _fetchNearbyCandidates(
+  Ref ref, {
+  required double latitude,
+  required double longitude,
+}) async {
+  var lastResult = <PhotoRestaurantCandidate>[];
+  for (final radius in _searchRadiiMeters) {
+    lastResult = await ref.read(
+      googleNearbyRestaurantServiceProvider(
+        latitude: latitude,
+        longitude: longitude,
+        radiusMeters: radius,
+      ).future,
+    );
+    if (lastResult.isNotEmpty || radius == _searchRadiiMeters.last) {
+      return lastResult;
+    }
+  }
+  return lastResult;
+}
+
+List<PhotoRestaurantCandidate> _mergeCandidates(
+  List<PhotoRestaurantCandidate> candidates,
+) {
+  final seen = <String>{};
+  final unique = <PhotoRestaurantCandidate>[];
+  for (final candidate in candidates) {
+    if (candidate.name.trim().isEmpty) {
+      continue;
+    }
+    final key =
+        '${candidate.name}_${candidate.lat.toStringAsFixed(4)}_${candidate.lng.toStringAsFixed(4)}';
+    if (seen.add(key)) {
+      unique.add(candidate);
+    }
+  }
+  return unique;
+}
+
+/// 近い距離帯から優先して最大10件（純粋に距離順）
+List<PhotoRestaurantCandidate> _pickClosest(
+  List<PhotoRestaurantCandidate> candidates,
+) {
+  final sorted = [...candidates]
+    ..sort((a, b) => a.distanceMeters.compareTo(b.distanceMeters));
+
+  for (final maxDist in _displayDistanceTiersMeters) {
+    final tier = sorted.where((c) => c.distanceMeters <= maxDist).toList();
+    if (tier.length >= _maxCandidates ||
+        maxDist == _displayDistanceTiersMeters.last) {
+      return tier.take(_maxCandidates).toList();
+    }
+  }
+
+  return sorted.take(_maxCandidates).toList();
+}

--- a/lib/core/api/restaurant/services/google_nearby_restaurant_service.dart
+++ b/lib/core/api/restaurant/services/google_nearby_restaurant_service.dart
@@ -44,7 +44,8 @@ Future<List<PhotoRestaurantCandidate>> googleNearbyRestaurantService(
 
     if (response.status != 200) {
       logger.w(
-        'Nearby search non-200: status=${response.status}, data=${response.data}',
+        'Nearby search non-200: status=${response.status}, '
+        'data=${response.data}',
       );
       return [];
     }
@@ -58,7 +59,8 @@ Future<List<PhotoRestaurantCandidate>> googleNearbyRestaurantService(
     final places = data['places'] as List<dynamic>? ?? [];
     if (places.isEmpty) {
       logger.i(
-        'Nearby search empty: lat=$latitude, lng=$longitude, radius=$radiusMeters',
+        'Nearby search empty: lat=$latitude, lng=$longitude, '
+        'radius=$radiusMeters',
       );
     }
 
@@ -104,10 +106,9 @@ PhotoRestaurantCandidate? _parsePlace({
   final openingHours = json['currentOpeningHours'] as Map<String, dynamic>?;
   final isOpenNow = openingHours?['openNow'] as bool?;
 
-  final types = (json['types'] as List<dynamic>?)
-          ?.map((e) => e.toString())
-          .toList() ??
-      [];
+  final types =
+      (json['types'] as List<dynamic>?)?.map((e) => e.toString()).toList() ??
+          [];
 
   final displayName = json['displayName'] as Map<String, dynamic>?;
   final name = displayName?['text'] as String? ?? '';

--- a/lib/core/api/restaurant/services/google_nearby_restaurant_service.dart
+++ b/lib/core/api/restaurant/services/google_nearby_restaurant_service.dart
@@ -72,7 +72,7 @@ Future<List<PhotoRestaurantCandidate>> googleNearbyRestaurantService(
         )
         .whereType<PhotoRestaurantCandidate>()
         .toList();
-  } on Exception catch (e, st) {
+  } on Object catch (e, st) {
     logger.w('Nearby search error', error: e, stackTrace: st);
     return [];
   }

--- a/lib/core/api/restaurant/services/google_nearby_restaurant_service.dart
+++ b/lib/core/api/restaurant/services/google_nearby_restaurant_service.dart
@@ -1,0 +1,143 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:food_gram_app/core/api/restaurant/photo_nearby_food_types.dart';
+import 'package:food_gram_app/core/model/photo_restaurant_candidate.dart';
+import 'package:food_gram_app/core/supabase/current_user_provider.dart';
+import 'package:food_gram_app/core/utils/geo_distance.dart';
+import 'package:logger/logger.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'google_nearby_restaurant_service.g.dart';
+
+const _mallLikeTypes = {
+  'shopping_mall',
+  'transit_station',
+  'subway_station',
+  'train_station',
+  'department_store',
+  'food_court',
+};
+
+@riverpod
+Future<List<PhotoRestaurantCandidate>> googleNearbyRestaurantService(
+  Ref ref, {
+  required double latitude,
+  required double longitude,
+  required int radiusMeters,
+}) async {
+  final logger = Logger();
+  try {
+    final supabase = ref.read(supabaseProvider);
+    final response = await supabase.functions.invoke(
+      'google-place-nearby-search',
+      body: {
+        'latitude': latitude,
+        'longitude': longitude,
+        'radiusMeters': radiusMeters,
+        'maxResultCount': 20,
+        'includedTypes': photoNearbyFoodPlaceTypes,
+        'language': 'ja',
+        'platform': Platform.isIOS ? 'ios' : 'android',
+      },
+    );
+
+    if (response.status != 200) {
+      logger.w(
+        'Nearby search non-200: status=${response.status}, data=${response.data}',
+      );
+      return [];
+    }
+
+    final data = response.data as Map<String, dynamic>;
+    if (data.containsKey('error')) {
+      logger.w('Nearby search API error: ${data['error']}');
+      return [];
+    }
+
+    final places = data['places'] as List<dynamic>? ?? [];
+    if (places.isEmpty) {
+      logger.i(
+        'Nearby search empty: lat=$latitude, lng=$longitude, radius=$radiusMeters',
+      );
+    }
+
+    return places
+        .map(
+          (raw) => _parsePlace(
+            json: raw as Map<String, dynamic>,
+            photoLat: latitude,
+            photoLng: longitude,
+          ),
+        )
+        .whereType<PhotoRestaurantCandidate>()
+        .toList();
+  } on Exception catch (e, st) {
+    logger.w('Nearby search error', error: e, stackTrace: st);
+    return [];
+  }
+}
+
+PhotoRestaurantCandidate? _parsePlace({
+  required Map<String, dynamic> json,
+  required double photoLat,
+  required double photoLng,
+}) {
+  final businessStatus = json['businessStatus'] as String?;
+  if (businessStatus == 'CLOSED_PERMANENTLY') {
+    return null;
+  }
+
+  final location = json['location'] as Map<String, dynamic>?;
+  if (location == null) {
+    return null;
+  }
+  final lat = (location['latitude'] as num).toDouble();
+  final lng = (location['longitude'] as num).toDouble();
+  final distanceMeters = geoMeters(
+    lat1: photoLat,
+    lon1: photoLng,
+    lat2: lat,
+    lon2: lng,
+  );
+
+  final openingHours = json['currentOpeningHours'] as Map<String, dynamic>?;
+  final isOpenNow = openingHours?['openNow'] as bool?;
+
+  final types = (json['types'] as List<dynamic>?)
+          ?.map((e) => e.toString())
+          .toList() ??
+      [];
+
+  final displayName = json['displayName'] as Map<String, dynamic>?;
+  final name = displayName?['text'] as String? ?? '';
+  if (name.trim().isEmpty) {
+    return null;
+  }
+
+  return PhotoRestaurantCandidate(
+    name: name,
+    address: json['formattedAddress'] as String? ?? '',
+    lat: lat,
+    lng: lng,
+    distanceMeters: distanceMeters,
+    source: PhotoRestaurantSource.google,
+    rating: (json['rating'] as num?)?.toDouble(),
+    isOpenNow: isOpenNow,
+    hint: _mallHint(types, distanceMeters),
+  );
+}
+
+String? _mallHint(List<String> types, double distanceMeters) {
+  final hasMallLike = types.any(_mallLikeTypes.contains);
+  if (!hasMallLike && distanceMeters <= 50) {
+    return null;
+  }
+  if (hasMallLike) {
+    return 'mall_hint';
+  }
+  if (distanceMeters > 50) {
+    return 'distance_hint';
+  }
+  return null;
+}

--- a/lib/core/api/restaurant/services/google_photo_text_search_service.dart
+++ b/lib/core/api/restaurant/services/google_photo_text_search_service.dart
@@ -79,13 +79,18 @@ List<PhotoRestaurantCandidate> _dedupeByLocation(
   final seen = <String>{};
   final unique = <PhotoRestaurantCandidate>[];
   for (final candidate in candidates) {
-    final key =
-        '${candidate.name}_${candidate.lat.toStringAsFixed(4)}_${candidate.lng.toStringAsFixed(4)}';
+    final key = _locationKey(candidate);
     if (seen.add(key)) {
       unique.add(candidate);
     }
   }
   return unique;
+}
+
+String _locationKey(PhotoRestaurantCandidate candidate) {
+  final lat = candidate.lat.toStringAsFixed(4);
+  final lng = candidate.lng.toStringAsFixed(4);
+  return '${candidate.name}_${lat}_$lng';
 }
 
 PhotoRestaurantCandidate? _fromLegacyResult({

--- a/lib/core/api/restaurant/services/google_photo_text_search_service.dart
+++ b/lib/core/api/restaurant/services/google_photo_text_search_service.dart
@@ -60,7 +60,7 @@ Future<List<PhotoRestaurantCandidate>> googlePhotoTextSearchService(
           merged.add(candidate);
         }
       }
-    } on Exception catch (e, st) {
+    } on Object catch (e, st) {
       logger.w(
         'Photo text search error: query=$query',
         error: e,

--- a/lib/core/api/restaurant/services/google_photo_text_search_service.dart
+++ b/lib/core/api/restaurant/services/google_photo_text_search_service.dart
@@ -1,0 +1,118 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:food_gram_app/core/api/restaurant/photo_nearby_food_types.dart';
+import 'package:food_gram_app/core/model/photo_restaurant_candidate.dart';
+import 'package:food_gram_app/core/model/restaurant.dart';
+import 'package:food_gram_app/core/supabase/current_user_provider.dart';
+import 'package:food_gram_app/core/utils/geo_distance.dart';
+import 'package:logger/logger.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'google_photo_text_search_service.g.dart';
+
+/// Text Search で拾う最大距離（屋内GPSのズレを考慮）
+const photoNearbyTextSearchMaxMeters = 100.0;
+
+/// 写真の撮影位置を基準に、Google Text Search で飲食店を検索する。
+@riverpod
+Future<List<PhotoRestaurantCandidate>> googlePhotoTextSearchService(
+  Ref ref, {
+  required double latitude,
+  required double longitude,
+}) async {
+  final logger = Logger();
+  final location = '$latitude,$longitude';
+  final merged = <PhotoRestaurantCandidate>[];
+
+  for (final query in photoNearbyTextSearchQueries) {
+    try {
+      final supabase = ref.read(supabaseProvider);
+      final response = await supabase.functions.invoke(
+        'Google-Place-Restaurant-Search-',
+        body: {
+          'query': query,
+          'language': 'ja',
+          'location': location,
+          'platform': Platform.isIOS ? 'ios' : 'android',
+        },
+      );
+
+      if (response.status != 200) {
+        logger.w(
+          'Photo text search non-200: query=$query, '
+          'status=${response.status}, data=${response.data}',
+        );
+        continue;
+      }
+
+      final data = response.data as Map<String, dynamic>;
+      final results = data['results'] as List<dynamic>? ?? [];
+
+      for (final raw in results) {
+        final candidate = _fromLegacyResult(
+          json: raw as Map<String, dynamic>,
+          photoLat: latitude,
+          photoLng: longitude,
+        );
+        if (candidate != null &&
+            candidate.distanceMeters <= photoNearbyTextSearchMaxMeters) {
+          merged.add(candidate);
+        }
+      }
+    } on Exception catch (e, st) {
+      logger.w(
+        'Photo text search error: query=$query',
+        error: e,
+        stackTrace: st,
+      );
+    }
+  }
+
+  return _dedupeByLocation(merged)
+    ..sort((a, b) => a.distanceMeters.compareTo(b.distanceMeters));
+}
+
+List<PhotoRestaurantCandidate> _dedupeByLocation(
+  List<PhotoRestaurantCandidate> candidates,
+) {
+  final seen = <String>{};
+  final unique = <PhotoRestaurantCandidate>[];
+  for (final candidate in candidates) {
+    final key =
+        '${candidate.name}_${candidate.lat.toStringAsFixed(4)}_${candidate.lng.toStringAsFixed(4)}';
+    if (seen.add(key)) {
+      unique.add(candidate);
+    }
+  }
+  return unique;
+}
+
+PhotoRestaurantCandidate? _fromLegacyResult({
+  required Map<String, dynamic> json,
+  required double photoLat,
+  required double photoLng,
+}) {
+  try {
+    final restaurant = Restaurant.fromJson(json);
+    if (restaurant.name.trim().isEmpty) {
+      return null;
+    }
+    final distanceMeters = geoMeters(
+      lat1: photoLat,
+      lon1: photoLng,
+      lat2: restaurant.lat,
+      lon2: restaurant.lng,
+    );
+    return PhotoRestaurantCandidate(
+      name: restaurant.name,
+      address: restaurant.address,
+      lat: restaurant.lat,
+      lng: restaurant.lng,
+      distanceMeters: distanceMeters,
+      source: PhotoRestaurantSource.google,
+    );
+  } on Object {
+    return null;
+  }
+}

--- a/lib/core/model/photo_restaurant_candidate.dart
+++ b/lib/core/model/photo_restaurant_candidate.dart
@@ -1,0 +1,41 @@
+import 'package:food_gram_app/core/model/restaurant.dart';
+
+/// 写真の撮影位置から提案するレストラン候補
+class PhotoRestaurantCandidate {
+  const PhotoRestaurantCandidate({
+    required this.name,
+    required this.address,
+    required this.lat,
+    required this.lng,
+    required this.distanceMeters,
+    required this.source,
+    this.rating,
+    this.isOpenNow,
+    this.hint,
+  });
+
+  final String name;
+  final String address;
+  final double lat;
+  final double lng;
+  final double distanceMeters;
+  final PhotoRestaurantSource source;
+  final double? rating;
+  final bool? isOpenNow;
+  final String? hint;
+
+  Restaurant toRestaurant() => Restaurant(
+        name: name,
+        address: address,
+        lat: lat,
+        lng: lng,
+      );
+}
+
+enum PhotoRestaurantSource {
+  /// FoodGram の既存投稿から
+  community,
+
+  /// Google Places Nearby Search
+  google,
+}

--- a/lib/core/utils/image/upload_image_bytes.dart
+++ b/lib/core/utils/image/upload_image_bytes.dart
@@ -1,9 +1,7 @@
-import 'dart:typed_data';
-
 import 'package:flutter/foundation.dart';
 import 'package:image/image.dart' as img;
 
-/// 従来の [ImagePicker] 設定（maxWidth/maxHeight: 960, imageQuality: 100）に合わせる
+/// 従来の [Image Picker] 設定（maxWidth/maxHeight: 960, imageQuality: 100）に合わせる
 const double kUploadImageMaxDimension = 960;
 const int kUploadImageJpegQuality = 100;
 
@@ -25,7 +23,7 @@ Uint8List _encodeUploadJpeg(Uint8List bytes) {
       maxDimension: kUploadImageMaxDimension.round(),
     );
     return Uint8List.fromList(
-      img.encodeJpg(resized, quality: kUploadImageJpegQuality),
+      img.encodeJpg(resized),
     );
   } on Object {
     return bytes;

--- a/lib/ui/component/dialog/app_photo_nearby_restaurant_dialog.dart
+++ b/lib/ui/component/dialog/app_photo_nearby_restaurant_dialog.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:food_gram_app/core/api/restaurant/repository/photo_nearby_restaurant_repository.dart';
+import 'package:food_gram_app/core/model/photo_restaurant_candidate.dart';
+import 'package:food_gram_app/core/model/restaurant.dart';
+import 'package:food_gram_app/gen/strings.g.dart';
+import 'package:food_gram_app/ui/screen/post/post_view_model.dart';
+import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// 写真の撮影位置から近くのレストラン候補をダイアログで表示する
+Future<void> showPhotoNearbyRestaurantDialog({
+  required BuildContext context,
+  required WidgetRef ref,
+  required String routerPath,
+  required double latitude,
+  required double longitude,
+}) async {
+  final vm = ref.read(postViewModelProvider().notifier);
+  var handled = false;
+
+  await showDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    builder: (dialogContext) => Consumer(
+      builder: (context, ref, _) {
+        final t = Translations.of(context);
+        final scheme = Theme.of(dialogContext).colorScheme;
+        final candidatesAsync = ref.watch(
+          photoNearbyRestaurantProvider(
+            latitude: latitude,
+            longitude: longitude,
+          ),
+        );
+
+        return AlertDialog(
+          backgroundColor: scheme.surface,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          title: Text(
+            t.post.nearbySuggestionTitle,
+            style: TextStyle(
+              fontSize: 17,
+              fontWeight: FontWeight.bold,
+              color: scheme.onSurface,
+            ),
+          ),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: candidatesAsync.when(
+              loading: () => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const CircularProgressIndicator(),
+                    const Gap(16),
+                    Text(
+                      t.map.loadingRestaurant,
+                      style: TextStyle(color: scheme.onSurfaceVariant),
+                    ),
+                  ],
+                ),
+              ),
+              error: (_, __) => Text(
+                t.post.nearbyFetchError,
+                style: TextStyle(color: scheme.onSurfaceVariant),
+              ),
+              data: (candidates) {
+                if (candidates.isEmpty) {
+                  return Text(
+                    t.post.nearbyEmpty,
+                    style: TextStyle(color: scheme.onSurfaceVariant),
+                  );
+                }
+                return ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxHeight: MediaQuery.of(dialogContext).size.height * 0.45,
+                  ),
+                  child: ListView.separated(
+                    shrinkWrap: true,
+                    itemCount: candidates.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final candidate = candidates[index];
+                      final distance =
+                          _formatDistance(t, candidate.distanceMeters);
+                      final subtitle = _buildSubtitle(candidate, distance);
+                      return ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        title: Text(
+                          candidate.name,
+                          style: const TextStyle(fontWeight: FontWeight.w600),
+                        ),
+                        subtitle: Text(subtitle),
+                        trailing: const Icon(Icons.chevron_right),
+                        onTap: () {
+                          handled = true;
+                          Navigator.of(dialogContext).pop();
+                          vm.selectNearbyCandidate(candidate);
+                        },
+                      );
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+          actions: candidatesAsync.isLoading
+              ? null
+              : [
+                  TextButton(
+                    onPressed: () async {
+                      handled = true;
+                      Navigator.of(dialogContext).pop();
+                      vm.dismissNearbySuggestion();
+                      final result = await context.pushNamed(routerPath);
+                      if (result != null && context.mounted) {
+                        vm.getPlace(result as Restaurant);
+                      }
+                    },
+                    child: Text(t.post.nearbyManualSearch),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      handled = true;
+                      Navigator.of(dialogContext).pop();
+                      vm.postWithoutRestaurant();
+                    },
+                    child: Text(t.post.nearbyPostWithout),
+                  ),
+                ],
+        );
+      },
+    ),
+  );
+
+  if (!handled && context.mounted) {
+    final state = ref.read(postViewModelProvider());
+    if (state.restaurant == PostViewModel.defaultRestaurantText &&
+        !state.nearbySuggestionDismissed) {
+      vm.dismissNearbySuggestion();
+    }
+  }
+}
+
+String _formatDistance(Translations t, double meters) {
+  if (meters < 1000) {
+    final label = meters < 100
+        ? meters.toStringAsFixed(meters < 10 ? 1 : 0)
+        : meters.round().toString();
+    return t.post.nearbyDistanceMeters.replaceFirst('{distance}', label);
+  }
+  return '${(meters / 1000).toStringAsFixed(1)}km';
+}
+
+String _buildSubtitle(PhotoRestaurantCandidate candidate, String distance) {
+  final parts = <String>[
+    distance,
+    if (candidate.rating != null)
+      '★ ${candidate.rating!.toStringAsFixed(1)}',
+  ];
+  return parts.join(' · ');
+}

--- a/lib/ui/component/dialog/app_photo_nearby_restaurant_dialog.dart
+++ b/lib/ui/component/dialog/app_photo_nearby_restaurant_dialog.dart
@@ -22,7 +22,6 @@ Future<void> showPhotoNearbyRestaurantDialog({
 
   await showDialog<void>(
     context: context,
-    barrierDismissible: true,
     builder: (dialogContext) => Consumer(
       builder: (context, ref, _) {
         final t = Translations.of(context);
@@ -36,7 +35,9 @@ Future<void> showPhotoNearbyRestaurantDialog({
 
         return AlertDialog(
           backgroundColor: scheme.surface,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
           title: Text(
             t.post.nearbySuggestionTitle,
             style: TextStyle(
@@ -163,8 +164,7 @@ String _formatDistance(Translations t, double meters) {
 String _buildSubtitle(PhotoRestaurantCandidate candidate, String distance) {
   final parts = <String>[
     distance,
-    if (candidate.rating != null)
-      '★ ${candidate.rating!.toStringAsFixed(1)}',
+    if (candidate.rating != null) '★ ${candidate.rating!.toStringAsFixed(1)}',
   ];
   return parts.join(' · ');
 }

--- a/lib/ui/component/dialog/app_photo_nearby_restaurant_dialog.dart
+++ b/lib/ui/component/dialog/app_photo_nearby_restaurant_dialog.dart
@@ -114,6 +114,9 @@ Future<void> showPhotoNearbyRestaurantDialog({
                       handled = true;
                       Navigator.of(dialogContext).pop();
                       vm.dismissNearbySuggestion();
+                      if (!context.mounted) {
+                        return;
+                      }
                       final result = await context.pushNamed(routerPath);
                       if (result != null && context.mounted) {
                         vm.getPlace(result as Restaurant);
@@ -151,7 +154,10 @@ String _formatDistance(Translations t, double meters) {
         : meters.round().toString();
     return t.post.nearbyDistanceMeters.replaceFirst('{distance}', label);
   }
-  return '${(meters / 1000).toStringAsFixed(1)}km';
+  return t.post.nearbyDistanceKilometers.replaceFirst(
+    '{distance}',
+    (meters / 1000).toStringAsFixed(1),
+  );
 }
 
 String _buildSubtitle(PhotoRestaurantCandidate candidate, String distance) {

--- a/lib/ui/screen/post/post_screen.dart
+++ b/lib/ui/screen/post/post_screen.dart
@@ -16,6 +16,7 @@ import 'package:food_gram_app/ui/component/app_tag.dart';
 import 'package:food_gram_app/ui/component/app_text_field.dart';
 import 'package:food_gram_app/ui/component/common/app_loading.dart';
 import 'package:food_gram_app/ui/component/dialog/app_maybe_not_food_dialog.dart';
+import 'package:food_gram_app/ui/component/dialog/app_photo_nearby_restaurant_dialog.dart';
 import 'package:food_gram_app/ui/component/dialog/app_streak_dialog.dart';
 import 'package:food_gram_app/ui/component/modal_sheet/app_post_image_modal_sheet.dart';
 import 'package:food_gram_app/ui/screen/post/post_view_model.dart';
@@ -52,6 +53,19 @@ class PostScreen extends HookConsumerWidget {
         ),
       ),
     );
+    final nearbyTrigger = ref.watch(
+      postViewModelProvider().select(
+        (s) => (
+          photoLat: s.photoLat,
+          photoLng: s.photoLng,
+          dismissed: s.nearbySuggestionDismissed,
+          restaurant: s.restaurant,
+          hasImages: s.foodImages.isNotEmpty,
+          status: s.status,
+        ),
+      ),
+    );
+    final lastShownNearbyGps = useRef<String?>(null);
     final loading = ref.watch(loadingProvider);
     final foodTags = useState<List<String>>([]);
     final foodTexts = useMemoized(
@@ -129,6 +143,53 @@ class PostScreen extends HookConsumerWidget {
         return null;
       },
       [postState.status],
+    );
+    useEffect(
+      () {
+        final lat = nearbyTrigger.photoLat;
+        final lng = nearbyTrigger.photoLng;
+        if (!nearbyTrigger.hasImages || lat == null || lng == null) {
+          lastShownNearbyGps.value = null;
+          return null;
+        }
+        if (nearbyTrigger.dismissed) {
+          return null;
+        }
+        if (nearbyTrigger.restaurant != PostViewModel.defaultRestaurantText) {
+          return null;
+        }
+        if (nearbyTrigger.status == PostStatus.maybeNotFood.name) {
+          return null;
+        }
+
+        final gpsKey = '${lat}_$lng';
+        if (lastShownNearbyGps.value == gpsKey) {
+          return null;
+        }
+
+        WidgetsBinding.instance.addPostFrameCallback((_) async {
+          if (!context.mounted) {
+            return;
+          }
+          lastShownNearbyGps.value = gpsKey;
+          await showPhotoNearbyRestaurantDialog(
+            context: context,
+            ref: ref,
+            routerPath: routerPath,
+            latitude: lat,
+            longitude: lng,
+          );
+        });
+        return null;
+      },
+      [
+        nearbyTrigger.photoLat,
+        nearbyTrigger.photoLng,
+        nearbyTrigger.dismissed,
+        nearbyTrigger.restaurant,
+        nearbyTrigger.hasImages,
+        nearbyTrigger.status,
+      ],
     );
     // プレビューサイズに合わせて縮小デコード（物理解像度で指定）
     final devicePixelRatio = MediaQuery.of(context).devicePixelRatio;

--- a/lib/ui/screen/post/post_state.dart
+++ b/lib/ui/screen/post/post_state.dart
@@ -14,5 +14,10 @@ class PostState with _$PostState {
     @Default(0.0) double star,
     @Default(false) bool isAnonymous,
     @Default('') String priceCurrency,
+    /// 写真 EXIF から取得した撮影位置（候補提案用）
+    double? photoLat,
+    double? photoLng,
+    /// 候補リストを閉じた / 店舗を選択済み
+    @Default(false) bool nearbySuggestionDismissed,
   }) = _PostState;
 }

--- a/lib/ui/screen/post/post_view_model.dart
+++ b/lib/ui/screen/post/post_view_model.dart
@@ -37,6 +37,7 @@ class PostViewModel extends _$PostViewModel {
   late final TextEditingController _commentController;
   late final TextEditingController _priceController;
   final Map<String, Uint8List> _imageBytesMap = {};
+  final Map<String, ({double latitude, double longitude})> _imageGpsByPath = {};
   Completer<void>? _maybeNotFoodCompleter;
   bool _restoredFromDraft = false;
   bool _priceCurrencyManuallySet = false;
@@ -71,6 +72,7 @@ class PostViewModel extends _$PostViewModel {
       }
       _maybeNotFoodCompleter = null;
       _imageBytesMap.clear();
+      _imageGpsByPath.clear();
       _currencyAutoDetectSeq++;
     });
   }
@@ -103,6 +105,7 @@ class PostViewModel extends _$PostViewModel {
     await _submitPost(foodTag, parsed);
     if (state.isSuccess) {
       _imageBytesMap.clear();
+      _imageGpsByPath.clear();
     }
     loading.state = false;
     return state.isSuccess;
@@ -186,15 +189,15 @@ class PostViewModel extends _$PostViewModel {
 
   void removeImage(String imagePath) {
     _imageBytesMap.remove(imagePath);
+    _imageGpsByPath.remove(imagePath);
     final updatedImages =
         state.foodImages.where((path) => path != imagePath).toList();
     state = state.copyWith(
       foodImages: updatedImages,
-      photoLat: updatedImages.isEmpty ? null : state.photoLat,
-      photoLng: updatedImages.isEmpty ? null : state.photoLng,
       nearbySuggestionDismissed:
           updatedImages.isEmpty ? false : state.nearbySuggestionDismissed,
     );
+    _applyPhotoGpsFromImages(updatedImages);
   }
 
   Future<bool> _pickImage(
@@ -235,9 +238,7 @@ class PostViewModel extends _$PostViewModel {
       }
       for (final image in images) {
         unawaited(_tryApplyCurrencyFromImage(image.path));
-        final photoGps = state.photoLat == null
-            ? await readGpsFromImagePath(image.path)
-            : null;
+        final photoGps = await readGpsFromImagePath(image.path);
         final bytes = await _openImageEditor(context, image.path);
         if (bytes != null) {
           await _processImageFromBytes(bytes, photoGps: photoGps);
@@ -296,15 +297,36 @@ class PostViewModel extends _$PostViewModel {
       status:
           isFood ? PostStatus.photoSuccess.name : PostStatus.maybeNotFood.name,
     );
-    if (state.restaurant == defaultRestaurantText &&
-        state.photoLat == null &&
-        photoGps != null) {
-      state = state.copyWith(
-        photoLat: photoGps.latitude,
-        photoLng: photoGps.longitude,
-        nearbySuggestionDismissed: false,
-      );
+    if (photoGps != null) {
+      _imageGpsByPath[imagePath] = photoGps;
     }
+    if (state.restaurant == defaultRestaurantText) {
+      _applyPhotoGpsFromImages(updatedImages);
+    }
+  }
+
+  /// 残っている画像のうち先頭の GPS を photoLat/photoLng に反映する
+  void _applyPhotoGpsFromImages(List<String> imagePaths) {
+    for (final path in imagePaths) {
+      final gps = _imageGpsByPath[path];
+      if (gps != null) {
+        final gpsChanged = state.photoLat != gps.latitude ||
+            state.photoLng != gps.longitude;
+        state = state.copyWith(
+          photoLat: gps.latitude,
+          photoLng: gps.longitude,
+          nearbySuggestionDismissed:
+              gpsChanged ? false : state.nearbySuggestionDismissed,
+        );
+        return;
+      }
+    }
+    state = state.copyWith(
+      photoLat: null,
+      photoLng: null,
+      nearbySuggestionDismissed:
+          imagePaths.isEmpty ? false : state.nearbySuggestionDismissed,
+    );
   }
 
   Future<void> _waitMaybeNotFoodHandled() async {

--- a/lib/ui/screen/post/post_view_model.dart
+++ b/lib/ui/screen/post/post_view_model.dart
@@ -6,12 +6,12 @@ import 'package:flutter/services.dart';
 import 'package:food_gram_app/core/analytics/analytics_event.dart';
 import 'package:food_gram_app/core/analytics/firebase_analytics_service.dart';
 import 'package:food_gram_app/core/local/shared_preference.dart';
+import 'package:food_gram_app/core/model/photo_restaurant_candidate.dart';
 import 'package:food_gram_app/core/model/post_draft.dart';
 import 'package:food_gram_app/core/model/restaurant.dart';
 import 'package:food_gram_app/core/supabase/post/repository/post_repository.dart';
 import 'package:food_gram_app/core/utils/format/post_price_formatter.dart';
 import 'package:food_gram_app/core/utils/image/upload_image_bytes.dart';
-import 'package:food_gram_app/core/model/photo_restaurant_candidate.dart';
 import 'package:food_gram_app/core/utils/location/image_gps_reader.dart';
 import 'package:food_gram_app/core/utils/location/post_price_currency_from_location.dart';
 import 'package:food_gram_app/core/utils/provider/loading.dart';
@@ -195,7 +195,7 @@ class PostViewModel extends _$PostViewModel {
     state = state.copyWith(
       foodImages: updatedImages,
       nearbySuggestionDismissed:
-          updatedImages.isEmpty ? false : state.nearbySuggestionDismissed,
+          updatedImages.isNotEmpty && state.nearbySuggestionDismissed,
     );
     _applyPhotoGpsFromImages(updatedImages);
   }
@@ -310,13 +310,13 @@ class PostViewModel extends _$PostViewModel {
     for (final path in imagePaths) {
       final gps = _imageGpsByPath[path];
       if (gps != null) {
-        final gpsChanged = state.photoLat != gps.latitude ||
-            state.photoLng != gps.longitude;
+        final gpsChanged =
+            state.photoLat != gps.latitude || state.photoLng != gps.longitude;
         state = state.copyWith(
           photoLat: gps.latitude,
           photoLng: gps.longitude,
           nearbySuggestionDismissed:
-              gpsChanged ? false : state.nearbySuggestionDismissed,
+              !gpsChanged && state.nearbySuggestionDismissed,
         );
         return;
       }
@@ -325,7 +325,7 @@ class PostViewModel extends _$PostViewModel {
       photoLat: null,
       photoLng: null,
       nearbySuggestionDismissed:
-          imagePaths.isEmpty ? false : state.nearbySuggestionDismissed,
+          imagePaths.isNotEmpty && state.nearbySuggestionDismissed,
     );
   }
 

--- a/lib/ui/screen/post/post_view_model.dart
+++ b/lib/ui/screen/post/post_view_model.dart
@@ -11,6 +11,8 @@ import 'package:food_gram_app/core/model/restaurant.dart';
 import 'package:food_gram_app/core/supabase/post/repository/post_repository.dart';
 import 'package:food_gram_app/core/utils/format/post_price_formatter.dart';
 import 'package:food_gram_app/core/utils/image/upload_image_bytes.dart';
+import 'package:food_gram_app/core/model/photo_restaurant_candidate.dart';
+import 'package:food_gram_app/core/utils/location/image_gps_reader.dart';
 import 'package:food_gram_app/core/utils/location/post_price_currency_from_location.dart';
 import 'package:food_gram_app/core/utils/provider/loading.dart';
 import 'package:food_gram_app/core/vision/food_image_labeler.dart';
@@ -186,7 +188,13 @@ class PostViewModel extends _$PostViewModel {
     _imageBytesMap.remove(imagePath);
     final updatedImages =
         state.foodImages.where((path) => path != imagePath).toList();
-    state = state.copyWith(foodImages: updatedImages);
+    state = state.copyWith(
+      foodImages: updatedImages,
+      photoLat: updatedImages.isEmpty ? null : state.photoLat,
+      photoLng: updatedImages.isEmpty ? null : state.photoLng,
+      nearbySuggestionDismissed:
+          updatedImages.isEmpty ? false : state.nearbySuggestionDismissed,
+    );
   }
 
   Future<bool> _pickImage(
@@ -202,11 +210,12 @@ class PostViewModel extends _$PostViewModel {
         return false;
       }
       unawaited(_tryApplyCurrencyFromImage(image.path));
+      final photoGps = await readGpsFromImagePath(image.path);
       final bytes = await _openImageEditor(context, image.path);
       if (bytes == null) {
         return false;
       }
-      await _processImageFromBytes(bytes);
+      await _processImageFromBytes(bytes, photoGps: photoGps);
       return true;
     } on PlatformException catch (error) {
       _logger.e(error.message);
@@ -226,9 +235,12 @@ class PostViewModel extends _$PostViewModel {
       }
       for (final image in images) {
         unawaited(_tryApplyCurrencyFromImage(image.path));
+        final photoGps = state.photoLat == null
+            ? await readGpsFromImagePath(image.path)
+            : null;
         final bytes = await _openImageEditor(context, image.path);
         if (bytes != null) {
-          await _processImageFromBytes(bytes);
+          await _processImageFromBytes(bytes, photoGps: photoGps);
           if (state.status == PostStatus.maybeNotFood.name) {
             await _waitMaybeNotFoodHandled();
           }
@@ -256,17 +268,23 @@ class PostViewModel extends _$PostViewModel {
     return result;
   }
 
-  Future<void> _processImageFromBytes(Uint8List bytes) async {
+  Future<void> _processImageFromBytes(
+    Uint8List bytes, {
+    ({double latitude, double longitude})? photoGps,
+  }) async {
     final uploadBytes = await prepareUploadImageBytes(bytes);
     final dir = await getTemporaryDirectory();
     final file = File(
       '${dir.path}/food_gram_${DateTime.now().millisecondsSinceEpoch}.jpg',
     );
     await file.writeAsBytes(uploadBytes);
-    await _processImage(file);
+    await _processImage(file, photoGps: photoGps);
   }
 
-  Future<void> _processImage(File cropImage) async {
+  Future<void> _processImage(
+    File cropImage, {
+    ({double latitude, double longitude})? photoGps,
+  }) async {
     final imageBytes = await cropImage.readAsBytes();
     final imagePath = cropImage.path;
     _imageBytesMap[imagePath] = imageBytes;
@@ -278,6 +296,15 @@ class PostViewModel extends _$PostViewModel {
       status:
           isFood ? PostStatus.photoSuccess.name : PostStatus.maybeNotFood.name,
     );
+    if (state.restaurant == defaultRestaurantText &&
+        state.photoLat == null &&
+        photoGps != null) {
+      state = state.copyWith(
+        photoLat: photoGps.latitude,
+        photoLng: photoGps.longitude,
+        nearbySuggestionDismissed: false,
+      );
+    }
   }
 
   Future<void> _waitMaybeNotFoodHandled() async {
@@ -299,11 +326,29 @@ class PostViewModel extends _$PostViewModel {
     _updateRestaurantState(restaurant);
   }
 
+  void selectNearbyCandidate(PhotoRestaurantCandidate candidate) {
+    _updateRestaurantState(candidate.toRestaurant());
+  }
+
+  void dismissNearbySuggestion() {
+    state = state.copyWith(nearbySuggestionDismissed: true);
+  }
+
+  void postWithoutRestaurant() {
+    state = state.copyWith(
+      restaurant: '不明',
+      lat: 0,
+      lng: 0,
+      nearbySuggestionDismissed: true,
+    );
+  }
+
   void _updateRestaurantState(Restaurant restaurant) {
     state = state.copyWith(
       restaurant: restaurant.name,
       lat: restaurant.lat,
       lng: restaurant.lng,
+      nearbySuggestionDismissed: true,
     );
     unawaited(
       _tryApplyCurrencyFromCoordinates(restaurant.lat, restaurant.lng),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,8 +19,8 @@ dependencies:
   easy_debounce: ^2.0.3
   enum_to_string: ^2.0.1
   envied: ^1.0.0
-  firebase_analytics: ^11.6.0
   exif: ^3.3.0
+  firebase_analytics: ^11.6.0
   firebase_core: ^3.13.1
   firebase_messaging: ^15.1.3
   flutter:
@@ -47,6 +47,7 @@ dependencies:
   google_sign_in: ^6.1.4
   home_widget: ^0.8.1
   hooks_riverpod: ^2.4.9
+  image: ^4.8.0
   image_picker: ^1.0.4
   in_app_review: ^2.0.8
   intl: ^0.20.2
@@ -78,7 +79,6 @@ dependencies:
   timezone: ^0.10.1
   toastification: ^3.0.3
   url_launcher: ^6.2.1
-  image: ^4.8.0
 
 dev_dependencies:
   build_runner: ">=2.4.13 <2.9.0"


### PR DESCRIPTION
## Issue

- close #1088 

## 概要

- フードの写真の位置情報からレストランを自動で提案できるようにしました

## 追加したPackage

- なし

## Screenshot



https://github.com/user-attachments/assets/83b7f75d-9459-4538-9c12-44b7402df116




## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added nearby restaurant suggestions in photo-based posts, using the photo’s location to help users quickly pick a place.
  * Includes localized suggestion titles, distance (meters/kilometers), open/closed and rating where available.
  * Supports manual search and an option to post without selecting a restaurant.
  * Shows loading, empty, and error states during suggestion fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->