### PR TITLE
最新版でビルドできるように追記しました

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,10 +2,20 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Attach dev (Hot Reload)",
+            "request": "attach",
+            "type": "dart",
+            "deviceId": "00008110-0009593C34F1801E",
+            "args": [
+                "--device-connection=attached"
+            ]
+        },
+        {
             "name": "Debug dev",
             "request": "launch",
             "type": "dart",
             "flutterMode": "debug",
+            "deviceId": "00008110-0009593C34F1801E",
             "args": [
                 "--dart-define-from-file=dart_defines/dev.env"
             ]
@@ -15,6 +25,7 @@
             "request": "launch",
             "type": "dart",
             "flutterMode": "debug",
+            "deviceId": "00008110-0009593C34F1801E",
             "args": [
                 "--dart-define-from-file=dart_defines/prod.env"
             ]

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -9,10 +9,12 @@ PODS:
   - AppAuth/Core (1.7.6)
   - AppAuth/ExternalUserAgent (1.7.6):
     - AppAuth/Core
-  - AppCheckCore (11.2.0):
+  - AppCheckCore (11.3.0):
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
+    - PromisesSwift (~> 2.4)
+    - RecaptchaInterop (~> 101.0)
   - device_info_plus (0.0.1):
     - Flutter
   - Firebase/Analytics (11.15.0):
@@ -168,31 +170,31 @@ PODS:
   - GoogleToolboxForMac/StringEncoding (4.2.1):
     - GoogleToolboxForMac/Defines (= 4.2.1)
   - GoogleUserMessagingPlatform (3.1.0)
-  - GoogleUtilities/AppDelegateSwizzler (8.1.0):
+  - GoogleUtilities/AppDelegateSwizzler (8.1.1):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Environment (8.1.0):
+  - GoogleUtilities/Environment (8.1.1):
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Logger (8.1.0):
+  - GoogleUtilities/Logger (8.1.1):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/MethodSwizzler (8.1.0):
+  - GoogleUtilities/MethodSwizzler (8.1.1):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Network (8.1.0):
+  - GoogleUtilities/Network (8.1.1):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (8.1.0)":
+  - "GoogleUtilities/NSData+zlib (8.1.1)":
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (8.1.0)
-  - GoogleUtilities/Reachability (8.1.0):
+  - GoogleUtilities/Privacy (8.1.1)
+  - GoogleUtilities/Reachability (8.1.1):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/UserDefaults (8.1.0):
+  - GoogleUtilities/UserDefaults (8.1.1):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - GTMAppAuth (4.1.1):
@@ -273,21 +275,24 @@ PODS:
     - FlutterMacOS
   - permission_handler_apple (9.3.0):
     - Flutter
-  - PromisesObjC (2.4.0)
-  - purchases_flutter (9.10.1):
+  - PromisesObjC (2.4.1)
+  - PromisesSwift (2.4.1):
+    - PromisesObjC (= 2.4.1)
+  - purchases_flutter (10.3.0):
     - Flutter
-    - PurchasesHybridCommon (= 17.24.0)
-  - purchases_ui_flutter (9.10.1):
+    - PurchasesHybridCommon (= 18.15.1)
+  - purchases_ui_flutter (10.3.0):
     - Flutter
-    - PurchasesHybridCommonUI (= 17.24.0)
-  - PurchasesHybridCommon (17.24.0):
-    - RevenueCat (= 5.50.1)
-  - PurchasesHybridCommonUI (17.24.0):
-    - PurchasesHybridCommon (= 17.24.0)
-    - RevenueCatUI (= 5.50.1)
-  - RevenueCat (5.50.1)
-  - RevenueCatUI (5.50.1):
-    - RevenueCat (= 5.50.1)
+    - PurchasesHybridCommonUI (= 18.15.1)
+  - PurchasesHybridCommon (18.15.1):
+    - RevenueCat (= 5.78.0)
+  - PurchasesHybridCommonUI (18.15.1):
+    - PurchasesHybridCommon (= 18.15.1)
+    - RevenueCatUI (= 5.78.0)
+  - RecaptchaInterop (101.0.0)
+  - RevenueCat (5.78.0)
+  - RevenueCatUI (5.78.0):
+    - RevenueCat (= 5.78.0)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -375,8 +380,10 @@ SPEC REPOS:
     - MLKitVisionKit
     - nanopb
     - PromisesObjC
+    - PromisesSwift
     - PurchasesHybridCommon
     - PurchasesHybridCommonUI
+    - RecaptchaInterop
     - RevenueCat
     - RevenueCatUI
     - SSZipArchive
@@ -453,7 +460,7 @@ SPEC CHECKSUMS:
   app_links: 3dbc685f76b1693c66a6d9dd1e9ab6f73d97dc0a
   app_tracking_transparency: 3d84f147f67ca82d3c15355c36b1fa6b66ca7c92
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
-  AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
+  AppCheckCore: 214137f5c378d1dec88a68425c467fe65aaff637
   device_info_plus: 335f3ce08d2e174b9fdc3db3db0f4e3b1f66bd89
   Firebase: d99ac19b909cd2c548339c2241ecd0d1599ab02e
   firebase_analytics: 0e25ca1d4001ccedd40b4e5b74c0ec34e18f6425
@@ -483,10 +490,10 @@ SPEC CHECKSUMS:
   GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4
   GoogleToolboxForMac: d1a2cbf009c453f4d6ded37c105e2f67a32206d8
   GoogleUserMessagingPlatform: befe603da6501006420c206222acd449bba45a9c
-  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  GoogleUtilities: 4f2618a4a1e762a1ee134a1e2323bba9843e06da
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  home_widget: f169fc41fd807b4d46ab6615dc44d62adbf9f64f
+  home_widget: 54b4f6b36ed8d64cfee594a476225c35c3e45091
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   in_app_review: 7dd1ea365263f834b8464673f9df72c80c17c937
   map_launcher: fe43bda6720bb73c12fcc1bdd86123ff49a4d4d6
@@ -504,16 +511,18 @@ SPEC CHECKSUMS:
   MLKitVision: 45e79d68845a2de77e2dd4d7f07947f0ed157b0e
   MLKitVisionKit: 8a7abd5f11aeb1add2942a694c2685eca422a849
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  package_info_plus: 566e1b7a2f3900e4b0020914ad3fc051dcc95596
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
-  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  purchases_flutter: 9aed1e2e783aaf62222c582f2e5624c72ad8d05d
-  purchases_ui_flutter: 65838ec40ed6d186637d42727bd169ec72d20fc3
-  PurchasesHybridCommon: 3b79d2602b94ed9ee3e8c4b31be4cd2a640c9dc9
-  PurchasesHybridCommonUI: cb0d8e875a0a1594e003e21b0612eb40b2c508b1
-  RevenueCat: c676920ae9b3c9cd08c49d26e7cd4c04a0263069
-  RevenueCatUI: a0566e6da2a8ae917a00956e76b7aa474de62f14
+  PromisesObjC: 752c3227f599e3467650e47ea36f433eeb10c273
+  PromisesSwift: 217dea0fd5d2ad65222a109c48698add13cc1c5b
+  purchases_flutter: 81d3b317261b26756edbe4d2cc2cfd4686359e68
+  purchases_ui_flutter: db7503e6b0f384336b75d65d2583b5c4e97fd4d6
+  PurchasesHybridCommon: eed735a411c1aee8c05d62933fa7c4a40ede4009
+  PurchasesHybridCommonUI: 4f0efc542177185a0d38080bbc42210d4ac15f4a
+  RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
+  RevenueCat: f3641992451c1426da8d8d1466cec3bbdb765962
+  RevenueCatUI: 32998f100fe73f1d0172df7eef4f0dd1bc781a05
   share_plus: de6030e33b4e106470e09322d87cf2a4258d2d1d
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418
@@ -522,6 +531,6 @@ SPEC CHECKSUMS:
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
   webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
 
-PODFILE CHECKSUM: f46793ee6f2d2737b61bb2598b90bba249f2a331
+PODFILE CHECKSUM: 969740d9a10dfb194eb98a5846a7c18b6f3666dc
 
 COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		6D17F47D2CFDD8C7008B8435 /* HomeWidgetSampleExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 6D17F4682CFDD8C3008B8435 /* HomeWidgetSampleExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		6D518B792B3168B7005D6CB9 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D518B782B3168B7005D6CB9 /* Environment.swift */; };
 		6DE199652D047DB30082E947 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6DE199642D047DB30082E947 /* StoreKit.framework */; };
+		6DF614811ED2DC5600515811 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF614801ED2DC5600515811 /* SceneDelegate.swift */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		82D2413079220D5D3F75CD06 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7B5D1A9EFD654F3112B37FBC /* GoogleService-Info.plist */; };
 		89DD1E713A057071CB0A1F2D /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E22BC7CB4DC941AF48EB1DE9 /* Pods_RunnerTests.framework */; };
@@ -105,6 +106,7 @@
 		6DF614782ECC6CF600795E98 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		6DF614792ECC6D0200795E98 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Main.strings; sourceTree = "<group>"; };
 		6DF6147A2ECC6D0200795E98 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		6DF614801ED2DC5600515811 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+				6DF614801ED2DC5600515811 /* SceneDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 				6D518B782B3168B7005D6CB9 /* Environment.swift */,
 			);
@@ -540,6 +543,7 @@
 			files = (
 				6D518B792B3168B7005D6CB9 /* Environment.swift in Sources */,
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
+				6DF614811ED2DC5600515811 /* SceneDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -648,7 +652,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -917,7 +921,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -968,7 +972,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -5,7 +5,7 @@ import FirebaseMessaging
 import UserNotifications
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -20,35 +20,33 @@ import UserNotifications
     if FirebaseApp.app() == nil {
       FirebaseApp.configure()
     }
-    
+
     // APNsトークンの登録
     application.registerForRemoteNotifications()
-    
+
     // アプリ起動時にバッジをクリア
     application.applicationIconBadgeNumber = 0
 
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
-  
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+  }
+
   // APNsトークンの登録成功時の処理
   override func application(_ application: UIApplication,
                             didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
     // Firebase MessagingにAPNsトークンを設定
     Messaging.messaging().apnsToken = deviceToken
   }
-  
+
   // APNsトークンの登録失敗時の処理
   override func application(_ application: UIApplication,
                             didFailToRegisterForRemoteNotificationsWithError error: Error) {
     print("APNsトークンの登録に失敗しました: \(error.localizedDescription)")
   }
-  
-  // アプリがフォアグラウンドに戻ったときにバッジをクリア
-  override func applicationDidBecomeActive(_ application: UIApplication) {
-    application.applicationIconBadgeNumber = 0
-  }
-  
+
   // 通知を受信したときの処理（バックグラウンドでも動作）
   override func application(_ application: UIApplication,
                             didReceiveRemoteNotification userInfo: [AnyHashable: Any],
@@ -57,7 +55,7 @@ import UserNotifications
     Messaging.messaging().appDidReceiveMessage(userInfo)
     completionHandler(.newData)
   }
-  
+
   // ディープリンク処理: アプリがURLで開かれたとき
   override func application(_ app: UIApplication,
                             open url: URL,
@@ -65,7 +63,7 @@ import UserNotifications
     // FlutterAppDelegateが自動的に処理する
     return super.application(app, open: url, options: options)
   }
-  
+
   // ディープリンク処理: アプリがバックグラウンドでURLで開かれたとき
   override func application(_ application: UIApplication,
                             continue userActivity: NSUserActivity,

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -255,6 +255,27 @@
 			<string>3qcr597p9d.skadnetwork</string>
 		</dict>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/ios/Runner/SceneDelegate.swift
+++ b/ios/Runner/SceneDelegate.swift
@@ -1,0 +1,9 @@
+import Flutter
+import UIKit
+
+class SceneDelegate: FlutterSceneDelegate {
+  override func sceneDidBecomeActive(_ scene: UIScene) {
+    super.sceneDidBecomeActive(scene)
+    UIApplication.shared.applicationIconBadgeNumber = 0
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1657,18 +1657,18 @@ packages:
     dependency: "direct main"
     description:
       name: purchases_flutter
-      sha256: e62dba6e5bbe985797b6ff0fc00e0ce3188f6cd3983b9d5a1a89a3e40dc79f9f
+      sha256: "7e849e3a94011109c4b91e1be65871bdb0f6aa3d577aee0764fbdb69b3eb6181"
       url: "https://pub.dev"
     source: hosted
-    version: "9.10.1"
+    version: "10.3.0"
   purchases_ui_flutter:
     dependency: "direct main"
     description:
       name: purchases_ui_flutter
-      sha256: "501ee1dfe9555e8b0841797596180d8e54d40c43527f511cbee455c447c00613"
+      sha256: "7ec221d1511e57941fc56a34f13026fd973f3d755d29b962c99f3c551760ac74"
       url: "https://pub.dev"
     source: hosted
-    version: "9.10.1"
+    version: "10.3.0"
   quickalert:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,8 +64,8 @@ dependencies:
   permission_handler: ^11.3.1
   photo_viewer: ^0.0.3
   pro_image_editor: ^12.0.1
-  purchases_flutter: ^9.9.10
-  purchases_ui_flutter: ^9.9.10
+  purchases_flutter: ^10.3.0
+  purchases_ui_flutter: ^10.3.0
   quickalert: ^1.1.0
   riverpod_annotation: ^2.0.0
   screenshot: ^3.0.0


### PR DESCRIPTION
## Issue

- close #ISSUE_NUMBER

## 概要

- 最新版でビルドできるように追記しました
- どうやらなんかメモリ不足とかでFlutter側でビルドができない😂

### 解決策
- Xcodeで実機ビルド
- Attach dev (Hot Reload)をタップしてそこからCoursorで操作できる

## 追加したPackage

-

## Screenshot


## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated in-app purchase library to latest major version for improved features and compatibility.
  * Raised minimum iOS deployment target to 15.5; devices running iOS 13–15.4 are no longer supported.

* **Improvements**
  * Enhanced app lifecycle management on iOS for better stability and responsiveness when returning to the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->