### PR TITLE
広告を追加で入れてみたよ

### DIFF
--- a/lib/core/admob/config/admob_config.dart
+++ b/lib/core/admob/config/admob_config.dart
@@ -49,8 +49,8 @@ String get appOpenAdUnitId {
 const Duration minInterstitialDuration = Duration(minutes: 3);
 const Duration minAppOpenDuration = Duration(minutes: 5);
 
-// タブを開いたときのアプリオープン広告（N回に1回）
-const tabOpenAdInterval = 10;
+// タブ切り替えN回ごとのアプリオープン広告
+const tabOpenAdInterval = 5;
 
 // テスト用広告IDを管理するクラス
 class _TestAdIds {

--- a/lib/core/admob/config/admob_config.dart
+++ b/lib/core/admob/config/admob_config.dart
@@ -49,6 +49,9 @@ String get appOpenAdUnitId {
 const Duration minInterstitialDuration = Duration(minutes: 3);
 const Duration minAppOpenDuration = Duration(minutes: 5);
 
+// タブを開いたときのアプリオープン広告（N回に1回）
+const tabOpenAdInterval = 10;
+
 // テスト用広告IDを管理するクラス
 class _TestAdIds {
   const _TestAdIds({

--- a/lib/core/admob/services/admob_interstitial.dart
+++ b/lib/core/admob/services/admob_interstitial.dart
@@ -22,6 +22,7 @@ class AdmobInterstitial {
 
   InterstitialAd? _interstitialAd;
   bool _isAdReady = false;
+  bool _isAdLoading = false;
   int _loadAttempts = 0;
   bool _isAdShowing = false;
   DateTime? _lastAdShowTime;
@@ -33,10 +34,11 @@ class AdmobInterstitial {
     if (isSubscribed) {
       return;
     }
-    if (_isAdReady || _loadAttempts >= maxLoadAttempts) {
+    if (_isAdReady || _isAdLoading || _loadAttempts >= maxLoadAttempts) {
       return;
     }
 
+    _isAdLoading = true;
     InterstitialAd.load(
       adUnitId: interstitialAdUnitId,
       request: const AdRequest(),
@@ -49,14 +51,17 @@ class AdmobInterstitial {
 
   void _onAdLoaded(InterstitialAd ad) {
     logger.d('Interstitial ad loaded successfully');
+    _interstitialAd?.dispose();
     _interstitialAd = ad;
     _isAdReady = true;
+    _isAdLoading = false;
     _loadAttempts = 0;
     onAdStateChanged?.call(isReady: true);
   }
 
   void _onAdFailedToLoad(LoadAdError error) {
     logger.e('Interstitial ad failed to load: ${error.message}');
+    _isAdLoading = false;
     _loadAttempts++;
     if (_loadAttempts < maxLoadAttempts) {
       createAd();
@@ -84,8 +89,11 @@ class AdmobInterstitial {
   }
 
   bool _canShowAd() {
-    if (_isAdShowing || _interstitialAd == null) {
-      logger.e('Attempted to show ad before it was ready');
+    if (_isAdShowing) {
+      return false;
+    }
+    if (_interstitialAd == null) {
+      logger.d('Interstitial ad is not ready yet');
       return false;
     }
 
@@ -147,6 +155,7 @@ class AdmobInterstitial {
     _interstitialAd?.dispose();
     _interstitialAd = null;
     _isAdReady = false;
+    _isAdLoading = false;
     _isAdShowing = false;
   }
 }
@@ -164,11 +173,8 @@ class AdmobInterstitialNotifier extends _$AdmobInterstitialNotifier {
 
     return subscriptionState.when(
       data: (isSubscribed) {
-        if (_admobInterstitial == null) {
-          _admobInterstitial = AdmobInterstitial(isSubscribed: isSubscribed);
-          _admobInterstitial!.createAd();
-        } else {
-          // サブスクリプション状態が変更された場合、新しいインスタンスを作成
+        if (_admobInterstitial == null ||
+            _admobInterstitial!.isSubscribed != isSubscribed) {
           _admobInterstitial?.dispose();
           _admobInterstitial = AdmobInterstitial(isSubscribed: isSubscribed);
           _admobInterstitial!.createAd();

--- a/lib/core/admob/services/admob_interstitial.dart
+++ b/lib/core/admob/services/admob_interstitial.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:food_gram_app/core/admob/config/admob_config.dart';
 import 'package:food_gram_app/core/supabase/user/providers/is_subscribe_provider.dart';
@@ -16,6 +18,7 @@ class AdmobInterstitial {
 
   final logger = Logger();
   static const int maxLoadAttempts = 2;
+  static const Duration adReadyTimeout = Duration(seconds: 5);
 
   final bool isSubscribed;
   final void Function({required bool isReady})? onAdStateChanged;
@@ -30,9 +33,12 @@ class AdmobInterstitial {
   bool get isAdReady => _isAdReady;
 
   /// 広告を作成して読み込む
-  void createAd() {
+  void createAd({bool resetAttempts = false}) {
     if (isSubscribed) {
       return;
+    }
+    if (resetAttempts) {
+      _loadAttempts = 0;
     }
     if (_isAdReady || _isAdLoading || _loadAttempts >= maxLoadAttempts) {
       return;
@@ -68,8 +74,40 @@ class AdmobInterstitial {
     }
   }
 
+  /// 表示可能になるまで広告の読み込みを待つ
+  Future<bool> ensureAdReady({
+    Duration timeout = adReadyTimeout,
+    bool resetAttempts = false,
+  }) async {
+    if (isSubscribed) {
+      return false;
+    }
+    if (_interstitialAd != null) {
+      return true;
+    }
+
+    createAd(resetAttempts: resetAttempts);
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      if (_interstitialAd != null) {
+        return true;
+      }
+      if (!_isAdLoading && _loadAttempts >= maxLoadAttempts) {
+        logger.i('Interstitial ad load aborted after $maxLoadAttempts attempts');
+        return false;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+
+    logger.i('Interstitial ad load timed out after ${timeout.inSeconds}s');
+    return _interstitialAd != null;
+  }
+
   /// 広告を表示する
-  Future<void> showAd({VoidCallback? onAdClosed}) async {
+  Future<void> showAd({
+    VoidCallback? onAdClosed,
+    VoidCallback? onAdShown,
+  }) async {
     if (_isAdShowing) {
       logger.d('Interstitial ad is already showing');
       return;
@@ -89,7 +127,10 @@ class AdmobInterstitial {
       onAdClosed?.call();
     }
 
-    _setupFullScreenCallback(complete);
+    _setupFullScreenCallback(
+      onAdClosed: complete,
+      onAdShown: onAdShown,
+    );
     await _showAd(onShowFailed: complete);
   }
 
@@ -117,12 +158,16 @@ class AdmobInterstitial {
     return true;
   }
 
-  void _setupFullScreenCallback(VoidCallback onAdClosed) {
+  void _setupFullScreenCallback({
+    required VoidCallback onAdClosed,
+    VoidCallback? onAdShown,
+  }) {
     _interstitialAd!.fullScreenContentCallback = FullScreenContentCallback(
       onAdShowedFullScreenContent: (ad) {
         _isAdShowing = true;
         _lastAdShowTime = DateTime.now();
         logger.i('Ad displayed');
+        onAdShown?.call();
       },
       onAdDismissedFullScreenContent: (ad) {
         logger.i('Ad dismissed');

--- a/lib/core/admob/services/admob_interstitial.dart
+++ b/lib/core/admob/services/admob_interstitial.dart
@@ -26,6 +26,8 @@ class AdmobInterstitial {
   InterstitialAd? _interstitialAd;
   bool _isAdReady = false;
   bool _isAdLoading = false;
+  bool _isDisposed = false;
+  int _loadGeneration = 0;
   int _loadAttempts = 0;
   bool _isAdShowing = false;
   DateTime? _lastAdShowTime;
@@ -34,7 +36,7 @@ class AdmobInterstitial {
 
   /// 広告を作成して読み込む
   void createAd({bool resetAttempts = false}) {
-    if (isSubscribed) {
+    if (isSubscribed || _isDisposed) {
       return;
     }
     if (resetAttempts) {
@@ -44,18 +46,23 @@ class AdmobInterstitial {
       return;
     }
 
+    final loadGeneration = ++_loadGeneration;
     _isAdLoading = true;
     InterstitialAd.load(
       adUnitId: interstitialAdUnitId,
       request: const AdRequest(),
       adLoadCallback: InterstitialAdLoadCallback(
-        onAdLoaded: _onAdLoaded,
-        onAdFailedToLoad: _onAdFailedToLoad,
+        onAdLoaded: (ad) => _onAdLoaded(ad, loadGeneration),
+        onAdFailedToLoad: (error) => _onAdFailedToLoad(error, loadGeneration),
       ),
     );
   }
 
-  void _onAdLoaded(InterstitialAd ad) {
+  void _onAdLoaded(InterstitialAd ad, int loadGeneration) {
+    if (_isDisposed || loadGeneration != _loadGeneration) {
+      ad.dispose();
+      return;
+    }
     logger.d('Interstitial ad loaded successfully');
     _interstitialAd?.dispose();
     _interstitialAd = ad;
@@ -65,7 +72,10 @@ class AdmobInterstitial {
     onAdStateChanged?.call(isReady: true);
   }
 
-  void _onAdFailedToLoad(LoadAdError error) {
+  void _onAdFailedToLoad(LoadAdError error, int loadGeneration) {
+    if (_isDisposed || loadGeneration != _loadGeneration) {
+      return;
+    }
     logger.e('Interstitial ad failed to load: ${error.message}');
     _isAdLoading = false;
     _loadAttempts++;
@@ -82,25 +92,26 @@ class AdmobInterstitial {
     if (isSubscribed) {
       return false;
     }
-    if (_interstitialAd != null) {
+    if (_isAdReady && _interstitialAd != null) {
       return true;
     }
 
     createAd(resetAttempts: resetAttempts);
     final deadline = DateTime.now().add(timeout);
     while (DateTime.now().isBefore(deadline)) {
-      if (_interstitialAd != null) {
+      if (_isAdReady && _interstitialAd != null) {
         return true;
       }
       if (!_isAdLoading && _loadAttempts >= maxLoadAttempts) {
-        logger.i('Interstitial ad load aborted after $maxLoadAttempts attempts');
+        logger
+            .i('Interstitial ad load aborted after $maxLoadAttempts attempts');
         return false;
       }
       await Future<void>.delayed(const Duration(milliseconds: 100));
     }
 
     logger.i('Interstitial ad load timed out after ${timeout.inSeconds}s');
-    return _interstitialAd != null;
+    return _isAdReady && _interstitialAd != null;
   }
 
   /// 広告を表示する
@@ -138,7 +149,7 @@ class AdmobInterstitial {
     if (_isAdShowing) {
       return false;
     }
-    if (_interstitialAd == null) {
+    if (!_isAdReady || _interstitialAd == null) {
       logger.d('Interstitial ad is not ready yet');
       return false;
     }
@@ -206,6 +217,8 @@ class AdmobInterstitial {
   }
 
   void dispose() {
+    _loadGeneration++;
+    _isDisposed = true;
     _interstitialAd?.dispose();
     _interstitialAd = null;
     _isAdReady = false;

--- a/lib/core/admob/services/admob_interstitial.dart
+++ b/lib/core/admob/services/admob_interstitial.dart
@@ -70,6 +70,11 @@ class AdmobInterstitial {
 
   /// 広告を表示する
   Future<void> showAd({VoidCallback? onAdClosed}) async {
+    if (_isAdShowing) {
+      logger.d('Interstitial ad is already showing');
+      return;
+    }
+
     if (!_canShowAd()) {
       onAdClosed?.call();
       return;
@@ -115,19 +120,24 @@ class AdmobInterstitial {
   void _setupFullScreenCallback(VoidCallback onAdClosed) {
     _interstitialAd!.fullScreenContentCallback = FullScreenContentCallback(
       onAdShowedFullScreenContent: (ad) {
+        _isAdShowing = true;
         _lastAdShowTime = DateTime.now();
         logger.i('Ad displayed');
       },
       onAdDismissedFullScreenContent: (ad) {
         logger.i('Ad dismissed');
+        _isAdShowing = false;
         ad.dispose();
+        _interstitialAd = null;
         _isAdReady = false;
         createAd();
         onAdClosed();
       },
       onAdFailedToShowFullScreenContent: (ad, error) {
         logger.e('Failed to show ad: $error');
+        _isAdShowing = false;
         ad.dispose();
+        _interstitialAd = null;
         _isAdReady = false;
         createAd();
         onAdClosed();
@@ -137,17 +147,16 @@ class AdmobInterstitial {
 
   Future<void> _showAd({required VoidCallback onShowFailed}) async {
     try {
-      _isAdShowing = true;
       await _interstitialAd!.show();
+      logger.d('Interstitial show() called');
     } on Object catch (e) {
+      _isAdShowing = false;
       logger.e('Error showing interstitial ad: $e');
       await _interstitialAd?.dispose();
       _interstitialAd = null;
       _isAdReady = false;
       createAd();
       onShowFailed();
-    } finally {
-      _isAdShowing = false;
     }
   }
 
@@ -161,7 +170,7 @@ class AdmobInterstitial {
 }
 
 /// インタースティシャル広告の状態を管理するプロバイダー
-@riverpod
+@Riverpod(keepAlive: true)
 class AdmobInterstitialNotifier extends _$AdmobInterstitialNotifier {
   AdmobInterstitial? _admobInterstitial;
 

--- a/lib/core/admob/services/admob_open.dart
+++ b/lib/core/admob/services/admob_open.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:food_gram_app/core/admob/config/admob_config.dart';
 import 'package:food_gram_app/core/supabase/user/providers/is_subscribe_provider.dart';
@@ -15,24 +17,33 @@ class AdmobOpen {
 
   AppOpenAd? _appOpenAd;
   bool _isAdShowing = false;
+  bool _isAdLoading = false;
   int _loadAttempts = 0;
   DateTime? _lastAdShowTime;
-  final Map<int, int> _tabOpenCounts = {};
+  int _tabSwitchCount = 0;
   final logger = Logger();
   final bool isSubscribed;
 
   static const int maxLoadAttempts = 2;
+  static const Duration adReadyTimeout = Duration(seconds: 5);
+
+  bool get isAdReady => _appOpenAd != null;
 
   /// 広告を読み込む
-  void loadAd() {
+  void loadAd({bool resetAttempts = false}) {
     if (isSubscribed) {
       return;
     }
 
-    if (_appOpenAd != null || _loadAttempts >= maxLoadAttempts) {
+    if (resetAttempts) {
+      _loadAttempts = 0;
+    }
+
+    if (_appOpenAd != null || _isAdLoading || _loadAttempts >= maxLoadAttempts) {
       return;
     }
 
+    _isAdLoading = true;
     AppOpenAd.load(
       adUnitId: appOpenAdUnitId,
       request: const AdRequest(),
@@ -43,15 +54,53 @@ class AdmobOpen {
     );
   }
 
-  /// タブを開いた回数を記録し、表示タイミングかどうかを返す
-  bool registerTabOpenAndShouldShow(int tabIndex) {
-    final count = (_tabOpenCounts[tabIndex] ?? 0) + 1;
-    _tabOpenCounts[tabIndex] = count;
-    return count % tabOpenAdInterval == 0;
+  /// タブ切り替え回数を記録し、表示タイミングかどうかを返す
+  bool registerTabSwitchAndShouldShow() {
+    _tabSwitchCount++;
+    final shouldShow = _tabSwitchCount % tabOpenAdInterval == 0;
+    logger.d(
+      'Tab switch count: $_tabSwitchCount / interval: $tabOpenAdInterval, '
+      'shouldShow: $shouldShow',
+    );
+    return shouldShow;
+  }
+
+  /// 表示可能になるまで広告の読み込みを待つ
+  Future<bool> ensureAdReady({
+    Duration timeout = adReadyTimeout,
+    bool resetAttempts = false,
+  }) async {
+    if (isSubscribed) {
+      return false;
+    }
+    if (_appOpenAd != null) {
+      return true;
+    }
+
+    loadAd(resetAttempts: resetAttempts);
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      if (_appOpenAd != null) {
+        return true;
+      }
+      if (!_isAdLoading && _loadAttempts >= maxLoadAttempts) {
+        logger.i('App open ad load aborted after $maxLoadAttempts attempts');
+        return false;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+
+    logger.i('App open ad load timed out after ${timeout.inSeconds}s');
+    return _appOpenAd != null;
   }
 
   /// 広告が利用可能な場合に表示する
   Future<void> showAdIfAvailable({VoidCallback? onAdClosed}) async {
+    if (_isAdShowing) {
+      logger.d('App open ad is already showing');
+      return;
+    }
+
     if (!_canShowAd()) {
       onAdClosed?.call();
       return;
@@ -68,21 +117,28 @@ class AdmobOpen {
 
     _setupFullScreenCallback(complete);
     try {
-      _isAdShowing = true;
       await _appOpenAd!.show();
       logger.d('App open ad show() called');
     } on Object catch (e) {
+      _isAdShowing = false;
       logger.e('Error showing app open ad: $e');
       _disposeAd();
       loadAd();
       complete();
-    } finally {
-      _isAdShowing = false;
     }
   }
 
   bool _canShowAd() {
-    if (_isAdShowing || _appOpenAd == null || isSubscribed) {
+    if (isSubscribed) {
+      logger.d('App open ad skipped: subscribed');
+      return false;
+    }
+    if (_isAdShowing) {
+      logger.d('App open ad skipped: already showing');
+      return false;
+    }
+    if (_appOpenAd == null) {
+      logger.i('App open ad skipped: not loaded');
       return false;
     }
 
@@ -99,12 +155,15 @@ class AdmobOpen {
 
   void _onAdLoaded(AppOpenAd ad) {
     logger.d('App open ad loaded successfully');
+    _appOpenAd?.dispose();
     _appOpenAd = ad;
+    _isAdLoading = false;
     _loadAttempts = 0;
   }
 
   void _onAdFailedToLoad(LoadAdError error) {
     logger.e('App open ad failed to load: $error');
+    _isAdLoading = false;
     _loadAttempts++;
     if (_loadAttempts < maxLoadAttempts) {
       loadAd();
@@ -114,16 +173,19 @@ class AdmobOpen {
   void _setupFullScreenCallback(VoidCallback onAdClosed) {
     _appOpenAd?.fullScreenContentCallback = FullScreenContentCallback(
       onAdShowedFullScreenContent: (ad) {
+        _isAdShowing = true;
         _lastAdShowTime = DateTime.now();
         logger.i('App open ad showed');
       },
       onAdDismissedFullScreenContent: (ad) {
+        _isAdShowing = false;
         logger.i('App open ad dismissed');
         _disposeAd();
         loadAd();
         onAdClosed();
       },
       onAdFailedToShowFullScreenContent: (ad, error) {
+        _isAdShowing = false;
         logger.e('App open ad failed to show: $error');
         _disposeAd();
         loadAd();
@@ -140,12 +202,13 @@ class AdmobOpen {
   void dispose() {
     _disposeAd();
     _isAdShowing = false;
-    _tabOpenCounts.clear();
+    _isAdLoading = false;
+    _tabSwitchCount = 0;
   }
 }
 
 /// アプリオープン広告の状態を管理するプロバイダー
-@riverpod
+@Riverpod(keepAlive: true)
 class AdmobOpenNotifier extends _$AdmobOpenNotifier {
   AdmobOpen? _admobOpen;
 
@@ -157,10 +220,7 @@ class AdmobOpenNotifier extends _$AdmobOpenNotifier {
 
     return subscriptionState.when(
       data: (isSubscribed) {
-        if (_admobOpen == null) {
-          _admobOpen = AdmobOpen(isSubscribed: isSubscribed);
-          _admobOpen!.loadAd();
-        } else {
+        if (_admobOpen == null || _admobOpen!.isSubscribed != isSubscribed) {
           _admobOpen?.dispose();
           _admobOpen = AdmobOpen(isSubscribed: isSubscribed);
           _admobOpen!.loadAd();

--- a/lib/core/admob/services/admob_open.dart
+++ b/lib/core/admob/services/admob_open.dart
@@ -20,12 +20,14 @@ class AdmobOpen {
   bool _isAdLoading = false;
   int _loadAttempts = 0;
   DateTime? _lastAdShowTime;
+  DateTime? _appOpenLoadTime;
   int _tabSwitchCount = 0;
   final logger = Logger();
   final bool isSubscribed;
 
   static const int maxLoadAttempts = 2;
   static const Duration adReadyTimeout = Duration(seconds: 5);
+  static const Duration maxCacheDuration = Duration(hours: 4);
 
   bool get isAdReady => _appOpenAd != null;
 
@@ -39,7 +41,9 @@ class AdmobOpen {
       _loadAttempts = 0;
     }
 
-    if (_appOpenAd != null || _isAdLoading || _loadAttempts >= maxLoadAttempts) {
+    if (_appOpenAd != null ||
+        _isAdLoading ||
+        _loadAttempts >= maxLoadAttempts) {
       return;
     }
 
@@ -74,7 +78,8 @@ class AdmobOpen {
       return false;
     }
     if (_appOpenAd != null) {
-      return true;
+      _discardExpiredAdIfNeeded();
+      return _appOpenAd != null;
     }
 
     loadAd(resetAttempts: resetAttempts);
@@ -137,6 +142,9 @@ class AdmobOpen {
       logger.d('App open ad skipped: already showing');
       return false;
     }
+
+    _discardExpiredAdIfNeeded();
+
     if (_appOpenAd == null) {
       logger.i('App open ad skipped: not loaded');
       return false;
@@ -157,6 +165,7 @@ class AdmobOpen {
     logger.d('App open ad loaded successfully');
     _appOpenAd?.dispose();
     _appOpenAd = ad;
+    _appOpenLoadTime = DateTime.now();
     _isAdLoading = false;
     _loadAttempts = 0;
   }
@@ -197,6 +206,19 @@ class AdmobOpen {
   void _disposeAd() {
     _appOpenAd?.dispose();
     _appOpenAd = null;
+    _appOpenLoadTime = null;
+  }
+
+  void _discardExpiredAdIfNeeded() {
+    if (_appOpenAd == null) {
+      return;
+    }
+    if (_appOpenLoadTime == null ||
+        DateTime.now().difference(_appOpenLoadTime!) > maxCacheDuration) {
+      logger.i('Discarding expired app open ad');
+      _disposeAd();
+      loadAd();
+    }
   }
 
   void dispose() {

--- a/lib/core/admob/services/admob_open.dart
+++ b/lib/core/admob/services/admob_open.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:food_gram_app/core/admob/config/admob_config.dart';
 import 'package:food_gram_app/core/supabase/user/providers/is_subscribe_provider.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
@@ -6,7 +7,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'admob_open.g.dart';
 
-/// アプリ起動時の広告を管理するクラス
+/// アプリオープン広告を管理するクラス
 class AdmobOpen {
   AdmobOpen({
     required this.isSubscribed,
@@ -14,8 +15,13 @@ class AdmobOpen {
 
   AppOpenAd? _appOpenAd;
   bool _isAdShowing = false;
+  int _loadAttempts = 0;
+  DateTime? _lastAdShowTime;
+  final Map<int, int> _tabOpenCounts = {};
   final logger = Logger();
   final bool isSubscribed;
+
+  static const int maxLoadAttempts = 2;
 
   /// 広告を読み込む
   void loadAd() {
@@ -23,7 +29,7 @@ class AdmobOpen {
       return;
     }
 
-    if (_appOpenAd != null) {
+    if (_appOpenAd != null || _loadAttempts >= maxLoadAttempts) {
       return;
     }
 
@@ -32,67 +38,113 @@ class AdmobOpen {
       request: const AdRequest(),
       adLoadCallback: AppOpenAdLoadCallback(
         onAdLoaded: _onAdLoaded,
-        onAdFailedToLoad: (error) =>
-            logger.e('App open ad failed to load: $error'),
+        onAdFailedToLoad: _onAdFailedToLoad,
       ),
     );
   }
 
+  /// タブを開いた回数を記録し、表示タイミングかどうかを返す
+  bool registerTabOpenAndShouldShow(int tabIndex) {
+    final count = (_tabOpenCounts[tabIndex] ?? 0) + 1;
+    _tabOpenCounts[tabIndex] = count;
+    return count % tabOpenAdInterval == 0;
+  }
+
   /// 広告が利用可能な場合に表示する
-  Future<void> showAdIfAvailable() async {
-    if (_isAdShowing || _appOpenAd == null || isSubscribed) {
+  Future<void> showAdIfAvailable({VoidCallback? onAdClosed}) async {
+    if (!_canShowAd()) {
+      onAdClosed?.call();
       return;
     }
 
+    var didComplete = false;
+    void complete() {
+      if (didComplete) {
+        return;
+      }
+      didComplete = true;
+      onAdClosed?.call();
+    }
+
+    _setupFullScreenCallback(complete);
     try {
       _isAdShowing = true;
-      await _appOpenAd?.show();
+      await _appOpenAd!.show();
       logger.d('App open ad show() called');
-    } on Exception catch (e) {
+    } on Object catch (e) {
       logger.e('Error showing app open ad: $e');
+      _disposeAd();
+      loadAd();
+      complete();
+    } finally {
       _isAdShowing = false;
-      _onAdClosed();
     }
+  }
+
+  bool _canShowAd() {
+    if (_isAdShowing || _appOpenAd == null || isSubscribed) {
+      return false;
+    }
+
+    if (_lastAdShowTime != null) {
+      final timeSinceLastAd = DateTime.now().difference(_lastAdShowTime!);
+      if (timeSinceLastAd < minAppOpenDuration) {
+        logger.i('Skipping app open ad due to minimum duration not met');
+        return false;
+      }
+    }
+
+    return true;
   }
 
   void _onAdLoaded(AppOpenAd ad) {
     logger.d('App open ad loaded successfully');
     _appOpenAd = ad;
-    _setupFullScreenCallback();
-    // 広告が読み込まれたら即座に表示を試みる
-    showAdIfAvailable();
+    _loadAttempts = 0;
   }
 
-  void _setupFullScreenCallback() {
+  void _onAdFailedToLoad(LoadAdError error) {
+    logger.e('App open ad failed to load: $error');
+    _loadAttempts++;
+    if (_loadAttempts < maxLoadAttempts) {
+      loadAd();
+    }
+  }
+
+  void _setupFullScreenCallback(VoidCallback onAdClosed) {
     _appOpenAd?.fullScreenContentCallback = FullScreenContentCallback(
       onAdShowedFullScreenContent: (ad) {
+        _lastAdShowTime = DateTime.now();
         logger.i('App open ad showed');
       },
       onAdDismissedFullScreenContent: (ad) {
         logger.i('App open ad dismissed');
-        _onAdClosed();
+        _disposeAd();
+        loadAd();
+        onAdClosed();
       },
       onAdFailedToShowFullScreenContent: (ad, error) {
         logger.e('App open ad failed to show: $error');
-        _onAdClosed();
+        _disposeAd();
+        loadAd();
+        onAdClosed();
       },
     );
   }
 
-  void _onAdClosed() {
+  void _disposeAd() {
     _appOpenAd?.dispose();
     _appOpenAd = null;
-    _isAdShowing = false;
   }
 
   void dispose() {
-    _appOpenAd?.dispose();
-    _appOpenAd = null;
+    _disposeAd();
     _isAdShowing = false;
+    _tabOpenCounts.clear();
   }
 }
 
-/// アプリ起動時の広告の状態を管理するプロバイダー
+/// アプリオープン広告の状態を管理するプロバイダー
 @riverpod
 class AdmobOpenNotifier extends _$AdmobOpenNotifier {
   AdmobOpen? _admobOpen;
@@ -107,20 +159,19 @@ class AdmobOpenNotifier extends _$AdmobOpenNotifier {
       data: (isSubscribed) {
         if (_admobOpen == null) {
           _admobOpen = AdmobOpen(isSubscribed: isSubscribed);
+          _admobOpen!.loadAd();
         } else {
-          // サブスクリプション状態が変更された場合、新しいインスタンスを作成
           _admobOpen?.dispose();
           _admobOpen = AdmobOpen(isSubscribed: isSubscribed);
+          _admobOpen!.loadAd();
         }
         return _admobOpen!;
       },
       loading: () {
-        // ローディング中は広告を表示しない
         _admobOpen ??= AdmobOpen(isSubscribed: true);
         return _admobOpen!;
       },
       error: (_, __) {
-        // エラー時は広告を表示しない
         _admobOpen ??= AdmobOpen(isSubscribed: true);
         return _admobOpen!;
       },

--- a/lib/core/config/constants/url.dart
+++ b/lib/core/config/constants/url.dart
@@ -49,5 +49,5 @@ class URL {
       'https://www.google.com/maps/search/?api=1&query=$restaurant';
 
   static String search(String restaurant) =>
-      'https://www.google.com/search?q=$restaurant';
+      'https://www.google.com/search?q=${Uri.encodeComponent(restaurant)}';
 }

--- a/lib/core/local/shared_preference.dart
+++ b/lib/core/local/shared_preference.dart
@@ -23,6 +23,7 @@ enum PreferenceKey {
   analyticsFirstCountryComplete,
   analyticsFirstPrefectureComplete,
   analyticsHighestPostMilestone,
+  recordTabInterstitialShown,
   memoryAlbums,
 }
 

--- a/lib/core/local/shared_preference.dart
+++ b/lib/core/local/shared_preference.dart
@@ -23,7 +23,6 @@ enum PreferenceKey {
   analyticsFirstCountryComplete,
   analyticsFirstPrefectureComplete,
   analyticsHighestPostMilestone,
-  recordTabInterstitialShown,
   memoryAlbums,
 }
 

--- a/lib/core/utils/helpers/url_launch_helper.dart
+++ b/lib/core/utils/helpers/url_launch_helper.dart
@@ -4,7 +4,7 @@ class LaunchUrlHelper {
   Future<bool> open(String uri) async {
     final url = Uri.parse(uri);
     if (await canLaunchUrl(url)) {
-      await launchUrl(url);
+      await launchUrl(url, mode: LaunchMode.externalApplication);
       return true;
     } else {
       return false;

--- a/lib/ui/screen/map/map_screen.dart
+++ b/lib/ui/screen/map/map_screen.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
-import 'dart:math' as math;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:food_gram_app/core/admob/services/admob_open.dart';
+import 'package:food_gram_app/core/admob/services/admob_interstitial.dart';
 import 'package:food_gram_app/core/admob/tracking/ad_tracking_permission.dart';
 import 'package:food_gram_app/core/analytics/analytics_event.dart';
 import 'package:food_gram_app/core/analytics/firebase_analytics_service.dart';
@@ -37,6 +36,7 @@ import 'package:maplibre_gl/maplibre_gl.dart';
 
 // 日本の中心付近の座標
 const defaultLocation = LatLng(36.2048, 137.9777);
+const mapPinTapAdInterval = 5;
 
 class MapScreen extends HookConsumerWidget {
   const MapScreen({super.key});
@@ -52,7 +52,9 @@ class MapScreen extends HookConsumerWidget {
     );
     final isEarthStyle = useState(false);
     final isSubscribeAsync = ref.watch(isSubscribeProvider);
-    final adLoadAttempted = useRef(false);
+    final pinTapCount = useRef(0);
+    final adInterstitial =
+        useMemoized(() => ref.read(admobInterstitialNotifierProvider));
     final isSubscribed = isSubscribeAsync.valueOrNull ?? false;
     final loading = ref.watch(loadingProvider);
     useEffect(
@@ -76,17 +78,10 @@ class MapScreen extends HookConsumerWidget {
     );
     useEffect(
       () {
-        if (adLoadAttempted.value) {
-          return null;
-        }
-        adLoadAttempted.value = true;
-        final value = math.Random().nextInt(8);
-        if (value == 0) {
-          ref.read(admobOpenNotifierProvider).loadAd();
-        }
-        return null;
+        adInterstitial.createAd();
+        return;
       },
-      [],
+      [adInterstitial],
     );
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final fabBg = isDark ? Colors.black : Colors.white;
@@ -128,12 +123,25 @@ class MapScreen extends HookConsumerWidget {
                               .read(firebaseAnalyticsServiceProvider)
                               .logMapPinTap(source: 'map');
                           final first = posts.first;
-                          ref.read(mapModalSelectionProvider.notifier).state =
-                              MapModalSelection(
-                            name: first.restaurant,
-                            lat: first.lat,
-                            lng: first.lng,
-                          );
+                          void openStoreSheet() {
+                            ref
+                                .read(mapModalSelectionProvider.notifier)
+                                .state = MapModalSelection(
+                              name: first.restaurant,
+                              lat: first.lat,
+                              lng: first.lng,
+                            );
+                          }
+
+                          pinTapCount.value++;
+                          if (pinTapCount.value >= mapPinTapAdInterval) {
+                            pinTapCount.value = 0;
+                            await adInterstitial.showAd(
+                              onAdClosed: openStoreSheet,
+                            );
+                          } else {
+                            openStoreSheet();
+                          }
                         },
                         iconSize: _calculateIconSize(context),
                         initialCenter: initialCenter,

--- a/lib/ui/screen/map/map_screen.dart
+++ b/lib/ui/screen/map/map_screen.dart
@@ -53,8 +53,7 @@ class MapScreen extends HookConsumerWidget {
     final isEarthStyle = useState(false);
     final isSubscribeAsync = ref.watch(isSubscribeProvider);
     final pinTapCount = useRef(0);
-    final adInterstitial =
-        useMemoized(() => ref.read(admobInterstitialNotifierProvider));
+    final adInterstitial = ref.watch(admobInterstitialNotifierProvider);
     final isSubscribed = isSubscribeAsync.valueOrNull ?? false;
     final loading = ref.watch(loadingProvider);
     useEffect(
@@ -75,13 +74,6 @@ class MapScreen extends HookConsumerWidget {
         return null;
       },
       [],
-    );
-    useEffect(
-      () {
-        adInterstitial.createAd();
-        return;
-      },
-      [adInterstitial],
     );
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final fabBg = isDark ? Colors.black : Colors.white;
@@ -133,6 +125,7 @@ class MapScreen extends HookConsumerWidget {
                             );
                           }
 
+                          adInterstitial.createAd();
                           pinTapCount.value++;
                           if (pinTapCount.value >= mapPinTapAdInterval) {
                             pinTapCount.value = 0;

--- a/lib/ui/screen/memory_album/memory_album_detail_screen.dart
+++ b/lib/ui/screen/memory_album/memory_album_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:easy_debounce/easy_debounce.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:food_gram_app/core/admob/services/admob_banner.dart';
 import 'package:food_gram_app/core/supabase/post/repository/detail_post_repository.dart';
 import 'package:food_gram_app/core/theme/memory_album_theme.dart';
 import 'package:food_gram_app/core/utils/helpers/dialog_helper.dart';
@@ -90,6 +91,12 @@ class MemoryAlbumDetailScreen extends HookConsumerWidget {
           backgroundColor: isDark
               ? Theme.of(context).scaffoldBackgroundColor
               : MemoryAlbumTheme.creamBackground,
+          bottomNavigationBar: const SafeArea(
+            child: Padding(
+              padding: EdgeInsets.only(bottom: 8, top: 4),
+              child: AdmobBanner(id: 'memory_album_detail_footer'),
+            ),
+          ),
           body: postsAsync.when(
             loading: () => const Center(child: AppContentLoading()),
             error: (_, __) => AppErrorWidget(
@@ -276,6 +283,7 @@ class MemoryAlbumDetailScreen extends HookConsumerWidget {
                       ),
                     ),
                   const SliverGap(24),
+                  const SliverGap(72),
                 ],
               );
             },

--- a/lib/ui/screen/memory_album/memory_album_detail_screen.dart
+++ b/lib/ui/screen/memory_album/memory_album_detail_screen.dart
@@ -282,7 +282,6 @@ class MemoryAlbumDetailScreen extends HookConsumerWidget {
                         childCount: sorted.length,
                       ),
                     ),
-                  const SliverGap(24),
                   const SliverGap(72),
                 ],
               );

--- a/lib/ui/screen/memory_album/memory_album_list_screen.dart
+++ b/lib/ui/screen/memory_album/memory_album_list_screen.dart
@@ -26,15 +26,8 @@ class MemoryAlbumListScreen extends HookConsumerWidget {
     final t = Translations.of(context);
     final albumsAsync = ref.watch(memoryAlbumListViewModelProvider);
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final adInterstitial =
-        useMemoized(() => ref.read(admobInterstitialNotifierProvider));
-    useEffect(
-      () {
-        adInterstitial.createAd();
-        return;
-      },
-      [adInterstitial],
-    );
+    final adInterstitial = ref.watch(admobInterstitialNotifierProvider);
+    final isOpeningAlbum = useRef(false);
 
     Future<void> reload() async {
       await ref.read(memoryAlbumListViewModelProvider.notifier).reload();
@@ -216,19 +209,27 @@ class MemoryAlbumListScreen extends HookConsumerWidget {
                         child: MemoryAlbumCard(
                           album: album,
                           onTap: () async {
+                            if (isOpeningAlbum.value) {
+                              return;
+                            }
+                            isOpeningAlbum.value = true;
                             await adInterstitial.showAd(
                               onAdClosed: () async {
-                                if (!context.mounted) {
-                                  return;
+                                try {
+                                  if (!context.mounted) {
+                                    return;
+                                  }
+                                  await context.pushNamed(
+                                    RouterPath.memoryAlbumDetail,
+                                    extra: album.id,
+                                  );
+                                  if (!context.mounted) {
+                                    return;
+                                  }
+                                  await reload();
+                                } finally {
+                                  isOpeningAlbum.value = false;
                                 }
-                                await context.pushNamed(
-                                  RouterPath.memoryAlbumDetail,
-                                  extra: album.id,
-                                );
-                                if (!context.mounted) {
-                                  return;
-                                }
-                                await reload();
                               },
                             );
                           },

--- a/lib/ui/screen/memory_album/memory_album_list_screen.dart
+++ b/lib/ui/screen/memory_album/memory_album_list_screen.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:food_gram_app/core/admob/services/admob_interstitial.dart';
 import 'package:food_gram_app/core/model/memory_album.dart';
 import 'package:food_gram_app/core/theme/memory_album_theme.dart';
 import 'package:food_gram_app/core/utils/helpers/dialog_helper.dart';
@@ -24,6 +26,15 @@ class MemoryAlbumListScreen extends HookConsumerWidget {
     final t = Translations.of(context);
     final albumsAsync = ref.watch(memoryAlbumListViewModelProvider);
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    final adInterstitial =
+        useMemoized(() => ref.read(admobInterstitialNotifierProvider));
+    useEffect(
+      () {
+        adInterstitial.createAd();
+        return;
+      },
+      [adInterstitial],
+    );
 
     Future<void> reload() async {
       await ref.read(memoryAlbumListViewModelProvider.notifier).reload();
@@ -205,14 +216,21 @@ class MemoryAlbumListScreen extends HookConsumerWidget {
                         child: MemoryAlbumCard(
                           album: album,
                           onTap: () async {
-                            await context.pushNamed(
-                              RouterPath.memoryAlbumDetail,
-                              extra: album.id,
+                            await adInterstitial.showAd(
+                              onAdClosed: () async {
+                                if (!context.mounted) {
+                                  return;
+                                }
+                                await context.pushNamed(
+                                  RouterPath.memoryAlbumDetail,
+                                  extra: album.id,
+                                );
+                                if (!context.mounted) {
+                                  return;
+                                }
+                                await reload();
+                              },
                             );
-                            if (!context.mounted) {
-                              return;
-                            }
-                            await reload();
                           },
                           onDelete: () => showAlbumActions(album),
                         ),

--- a/lib/ui/screen/post_detail/component/post_detail_list_item.dart
+++ b/lib/ui/screen/post_detail/component/post_detail_list_item.dart
@@ -49,6 +49,7 @@ class PostDetailListItem extends HookConsumerWidget {
     final isHearted = useState<bool>(false);
     final heartCount = useState<int>(posts.heart);
     final isStored = useState<bool?>(null);
+    final isOpeningSearch = useRef(false);
     // リスト再利用時も状態を保持
     useAutomaticKeepAlive();
     useEffect(
@@ -412,18 +413,28 @@ class PostDetailListItem extends HookConsumerWidget {
                         const Gap(4),
                         AppDetailElevatedButton(
                           onPressed: () async {
-                            final adInterstitial =
-                                ref.read(admobInterstitialNotifierProvider);
-                            adInterstitial.createAd();
-                            await adInterstitial.showAd(
-                              onAdClosed: () {
-                                ref
-                                    .read(
-                                      postDetailViewModelProvider().notifier,
-                                    )
-                                    .openUrl(posts.restaurant);
-                              },
-                            );
+                            if (isOpeningSearch.value) {
+                              return;
+                            }
+                            isOpeningSearch.value = true;
+                            try {
+                              final adInterstitial =
+                                  ref.read(admobInterstitialNotifierProvider);
+                              await adInterstitial.ensureAdReady(
+                                resetAttempts: true,
+                              );
+                              await adInterstitial.showAd(
+                                onAdClosed: () {
+                                  ref
+                                      .read(
+                                        postDetailViewModelProvider().notifier,
+                                      )
+                                      .openUrl(posts.restaurant);
+                                },
+                              );
+                            } finally {
+                              isOpeningSearch.value = false;
+                            }
                           },
                           title: t.detailMenu.search,
                           icon: Icons.search,

--- a/lib/ui/screen/post_detail/component/post_detail_list_item.dart
+++ b/lib/ui/screen/post_detail/component/post_detail_list_item.dart
@@ -414,6 +414,7 @@ class PostDetailListItem extends HookConsumerWidget {
                           onPressed: () async {
                             final adInterstitial =
                                 ref.read(admobInterstitialNotifierProvider);
+                            adInterstitial.createAd();
                             await adInterstitial.showAd(
                               onAdClosed: () {
                                 ref

--- a/lib/ui/screen/post_detail/component/post_detail_list_item.dart
+++ b/lib/ui/screen/post_detail/component/post_detail_list_item.dart
@@ -2,6 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:food_gram_app/core/admob/services/admob_interstitial.dart';
 import 'package:food_gram_app/core/local/shared_preference.dart';
 import 'package:food_gram_app/core/model/posts.dart';
 import 'package:food_gram_app/core/model/restaurant.dart';
@@ -410,9 +411,19 @@ class PostDetailListItem extends HookConsumerWidget {
                         ),
                         const Gap(4),
                         AppDetailElevatedButton(
-                          onPressed: () => ref
-                              .read(postDetailViewModelProvider().notifier)
-                              .openUrl(posts.restaurant),
+                          onPressed: () async {
+                            final adInterstitial =
+                                ref.read(admobInterstitialNotifierProvider);
+                            await adInterstitial.showAd(
+                              onAdClosed: () {
+                                ref
+                                    .read(
+                                      postDetailViewModelProvider().notifier,
+                                    )
+                                    .openUrl(posts.restaurant);
+                              },
+                            );
+                          },
                           title: t.detailMenu.search,
                           icon: Icons.search,
                         ),

--- a/lib/ui/screen/post_detail/post_detail_screen.dart
+++ b/lib/ui/screen/post_detail/post_detail_screen.dart
@@ -82,27 +82,32 @@ class PostDetailScreen extends HookConsumerWidget {
       ),
     );
     final isInitialLoading = listState.isLoading;
-    final adInterstitial =
-        useMemoized(() => ref.read(admobInterstitialNotifierProvider));
-    useEffect(
-      () {
-        adInterstitial.createAd();
-        return;
-      },
-      [adInterstitial],
-    );
+    final adInterstitial = ref.watch(admobInterstitialNotifierProvider);
+    final isClosing = useState(false);
 
     Future<void> closeDetail() async {
-      await adInterstitial.showAd(
-        onAdClosed: () {
-          if (context.mounted) {
-            context.pop();
-          }
-        },
-      );
+      if (isClosing.value ||
+          loading ||
+          menuLoading.value ||
+          isInitialLoading) {
+        return;
+      }
+      isClosing.value = true;
+      try {
+        await adInterstitial.showAd(
+          onAdClosed: () {
+            if (context.mounted) {
+              context.pop();
+            }
+          },
+        );
+      } finally {
+        isClosing.value = false;
+      }
     }
 
-    final canClose = !loading && !menuLoading.value && !isInitialLoading;
+    final canClose =
+        !loading && !menuLoading.value && !isInitialLoading && !isClosing.value;
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, result) {

--- a/lib/ui/screen/post_detail/post_detail_screen.dart
+++ b/lib/ui/screen/post_detail/post_detail_screen.dart
@@ -1,6 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:food_gram_app/core/admob/services/admob_banner.dart';
+import 'package:food_gram_app/core/admob/services/admob_interstitial.dart';
+import 'package:food_gram_app/core/admob/services/admob_rectangle_banner.dart';
 import 'package:food_gram_app/core/analytics/firebase_analytics_service.dart';
 import 'package:food_gram_app/core/model/post_deail_list_mode.dart';
 import 'package:food_gram_app/core/model/posts.dart';
@@ -78,8 +82,35 @@ class PostDetailScreen extends HookConsumerWidget {
       ),
     );
     final isInitialLoading = listState.isLoading;
+    final adInterstitial =
+        useMemoized(() => ref.read(admobInterstitialNotifierProvider));
+    useEffect(
+      () {
+        adInterstitial.createAd();
+        return;
+      },
+      [adInterstitial],
+    );
+
+    Future<void> closeDetail() async {
+      await adInterstitial.showAd(
+        onAdClosed: () {
+          if (context.mounted) {
+            context.pop();
+          }
+        },
+      );
+    }
+
+    final canClose = !loading && !menuLoading.value && !isInitialLoading;
     return PopScope(
-      canPop: !(loading || isInitialLoading),
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop || !canClose) {
+          return;
+        }
+        unawaited(closeDetail());
+      },
       child: Scaffold(
         appBar: AppBar(
           automaticallyImplyLeading: !(loading || isInitialLoading),
@@ -92,7 +123,7 @@ class PostDetailScreen extends HookConsumerWidget {
           leading: loading || menuLoading.value || isInitialLoading
               ? const SizedBox.shrink()
               : GestureDetector(
-                  onTap: () => context.pop(),
+                  onTap: closeDetail,
                   child: Icon(
                     Icons.close,
                     size: 30,
@@ -165,27 +196,36 @@ class PostDetailScreen extends HookConsumerWidget {
                 error: (error, stack) => const Center(
                   child: Text('エラーが発生しました'),
                 ),
-                data: (posts) => ListView.builder(
-                  controller: scrollController,
-                  key: PageStorageKey('post_detail_list_${memoizedPosts.id}'),
-                  restorationId: 'post_detail_list_${memoizedPosts.id}',
-                  cacheExtent: 2000,
-                  itemCount: posts.length,
-                  itemBuilder: (context, index) {
-                    final post = posts[index];
-                    return PostDetailListItem(
-                      key: ValueKey('post_${post.id}'),
-                      posts: post,
-                      menuLoading: menuLoading,
-                      onHeartLimitReached: () {
-                        SnackBarHelper().openWarningSnackBar(
-                          context,
-                          t.heartLimitMessage,
-                        );
-                      },
-                    );
-                  },
-                ),
+                data: (posts) {
+                  const adInterval = 2;
+                  final itemCount = posts.length + (posts.length ~/ adInterval);
+                  return ListView.builder(
+                    controller: scrollController,
+                    key: PageStorageKey('post_detail_list_${memoizedPosts.id}'),
+                    restorationId: 'post_detail_list_${memoizedPosts.id}',
+                    cacheExtent: 2000,
+                    itemCount: itemCount,
+                    itemBuilder: (context, index) {
+                      final isAdRow = (index + 1) % (adInterval + 1) == 0;
+                      if (isAdRow) {
+                        return RectangleBanner(id: 'detail_feed_$index');
+                      }
+                      final postIndex = index - (index ~/ (adInterval + 1));
+                      final post = posts[postIndex];
+                      return PostDetailListItem(
+                        key: ValueKey('post_${post.id}'),
+                        posts: post,
+                        menuLoading: menuLoading,
+                        onHeartLimitReached: () {
+                          SnackBarHelper().openWarningSnackBar(
+                            context,
+                            t.heartLimitMessage,
+                          );
+                        },
+                      );
+                    },
+                  );
+                },
               ),
               AppHeart(isHeart: detailState.isAppearHeart),
               AppProcessLoading(

--- a/lib/ui/screen/tab/tab_view_model.dart
+++ b/lib/ui/screen/tab/tab_view_model.dart
@@ -2,11 +2,9 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:food_gram_app/core/admob/services/admob_interstitial.dart';
 import 'package:food_gram_app/core/admob/services/admob_open.dart';
 import 'package:food_gram_app/core/analytics/analytics_event.dart';
 import 'package:food_gram_app/core/analytics/firebase_analytics_service.dart';
-import 'package:food_gram_app/core/local/shared_preference.dart';
 import 'package:food_gram_app/ui/screen/map/map_screen.dart';
 import 'package:food_gram_app/ui/screen/profile/my_profile/my_profile_screen.dart';
 import 'package:food_gram_app/ui/screen/record/record_screen.dart';
@@ -28,7 +26,6 @@ class TabViewModel extends _$TabViewModel {
   TabState build({
     TabState initState = const TabState(),
   }) {
-    ref.read(admobInterstitialNotifierProvider).createAd();
     ref.read(admobOpenNotifierProvider).loadAd();
     return initState;
   }
@@ -62,20 +59,6 @@ class TabViewModel extends _$TabViewModel {
 
       final appOpen = ref.read(admobOpenNotifierProvider);
       appOpen.loadAd();
-
-      if (index == 2) {
-        final hasShownAd = await Preference().getBool(
-          PreferenceKey.recordTabInterstitialShown,
-        );
-        if (!hasShownAd) {
-          await Preference().setBool(PreferenceKey.recordTabInterstitialShown);
-          appOpen.registerTabSwitchAndShouldShow();
-          final adInterstitial = ref.read(admobInterstitialNotifierProvider);
-          adInterstitial.createAd();
-          await adInterstitial.showAd(onAdClosed: switchTab);
-          return;
-        }
-      }
 
       if (appOpen.registerTabSwitchAndShouldShow()) {
         await appOpen.ensureAdReady(resetAttempts: true);

--- a/lib/ui/screen/tab/tab_view_model.dart
+++ b/lib/ui/screen/tab/tab_view_model.dart
@@ -22,6 +22,8 @@ final scrollToTopForTabProvider =
 
 @riverpod
 class TabViewModel extends _$TabViewModel {
+  bool _isHandlingTap = false;
+
   @override
   TabState build({
     TabState initState = const TabState(),
@@ -40,40 +42,51 @@ class TabViewModel extends _$TabViewModel {
   ];
 
   Future<void> onTap(int index) async {
-    if (index == state.selectedIndex) {
-      if (index == 1 || index == 3) {
-        final current = ref.read(scrollToTopForTabProvider);
-        ref.read(scrollToTopForTabProvider.notifier).state = (
-          tabIndex: index,
-          trigger: (current?.trigger ?? -1) + 1,
-        );
-      }
+    if (_isHandlingTap) {
       return;
     }
-
-    void switchTab() => _switchToTab(index);
-
-    if (index == 2) {
-      final hasShownAd = await Preference().getBool(
-        PreferenceKey.recordTabInterstitialShown,
-      );
-      if (!hasShownAd) {
-        await Preference().setBool(PreferenceKey.recordTabInterstitialShown);
-        final adInterstitial = ref.read(admobInterstitialNotifierProvider);
-        adInterstitial.createAd();
-        await adInterstitial.showAd(onAdClosed: switchTab);
+    _isHandlingTap = true;
+    try {
+      if (index == state.selectedIndex) {
+        if (index == 1 || index == 3) {
+          final current = ref.read(scrollToTopForTabProvider);
+          ref.read(scrollToTopForTabProvider.notifier).state = (
+            tabIndex: index,
+            trigger: (current?.trigger ?? -1) + 1,
+          );
+        }
         return;
       }
-    }
 
-    final appOpen = ref.read(admobOpenNotifierProvider);
-    if (appOpen.registerTabOpenAndShouldShow(index)) {
+      void switchTab() => _switchToTab(index);
+
+      final appOpen = ref.read(admobOpenNotifierProvider);
       appOpen.loadAd();
-      await appOpen.showAdIfAvailable(onAdClosed: switchTab);
-      return;
-    }
 
-    switchTab();
+      if (index == 2) {
+        final hasShownAd = await Preference().getBool(
+          PreferenceKey.recordTabInterstitialShown,
+        );
+        if (!hasShownAd) {
+          await Preference().setBool(PreferenceKey.recordTabInterstitialShown);
+          appOpen.registerTabSwitchAndShouldShow();
+          final adInterstitial = ref.read(admobInterstitialNotifierProvider);
+          adInterstitial.createAd();
+          await adInterstitial.showAd(onAdClosed: switchTab);
+          return;
+        }
+      }
+
+      if (appOpen.registerTabSwitchAndShouldShow()) {
+        await appOpen.ensureAdReady(resetAttempts: true);
+        await appOpen.showAdIfAvailable(onAdClosed: switchTab);
+        return;
+      }
+
+      switchTab();
+    } finally {
+      _isHandlingTap = false;
+    }
   }
 
   void _switchToTab(int index) {

--- a/lib/ui/screen/tab/tab_view_model.dart
+++ b/lib/ui/screen/tab/tab_view_model.dart
@@ -2,8 +2,11 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:food_gram_app/core/admob/services/admob_interstitial.dart';
+import 'package:food_gram_app/core/admob/services/admob_open.dart';
 import 'package:food_gram_app/core/analytics/analytics_event.dart';
 import 'package:food_gram_app/core/analytics/firebase_analytics_service.dart';
+import 'package:food_gram_app/core/local/shared_preference.dart';
 import 'package:food_gram_app/ui/screen/map/map_screen.dart';
 import 'package:food_gram_app/ui/screen/profile/my_profile/my_profile_screen.dart';
 import 'package:food_gram_app/ui/screen/record/record_screen.dart';
@@ -23,6 +26,8 @@ class TabViewModel extends _$TabViewModel {
   TabState build({
     TabState initState = const TabState(),
   }) {
+    ref.read(admobInterstitialNotifierProvider).createAd();
+    ref.read(admobOpenNotifierProvider).loadAd();
     return initState;
   }
 
@@ -34,7 +39,44 @@ class TabViewModel extends _$TabViewModel {
     const SettingScreen(),
   ];
 
-  void onTap(int index) {
+  Future<void> onTap(int index) async {
+    if (index == state.selectedIndex) {
+      if (index == 1 || index == 3) {
+        final current = ref.read(scrollToTopForTabProvider);
+        ref.read(scrollToTopForTabProvider.notifier).state = (
+          tabIndex: index,
+          trigger: (current?.trigger ?? -1) + 1,
+        );
+      }
+      return;
+    }
+
+    void switchTab() => _switchToTab(index);
+
+    if (index == 2) {
+      final hasShownAd = await Preference().getBool(
+        PreferenceKey.recordTabInterstitialShown,
+      );
+      if (!hasShownAd) {
+        await Preference().setBool(PreferenceKey.recordTabInterstitialShown);
+        final adInterstitial = ref.read(admobInterstitialNotifierProvider);
+        adInterstitial.createAd();
+        await adInterstitial.showAd(onAdClosed: switchTab);
+        return;
+      }
+    }
+
+    final appOpen = ref.read(admobOpenNotifierProvider);
+    if (appOpen.registerTabOpenAndShouldShow(index)) {
+      appOpen.loadAd();
+      await appOpen.showAdIfAvailable(onAdClosed: switchTab);
+      return;
+    }
+
+    switchTab();
+  }
+
+  void _switchToTab(int index) {
     final analytics = ref.read(firebaseAnalyticsServiceProvider);
     switch (index) {
       case 0:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1369,10 +1369,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -2062,10 +2062,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue

- close #1107 

## 概要

- 広告を追加で入れてみたよ

### 項目
タブ切り替え
- [x] 5回に1回 → アプリオープン → タブ遷移

マップ
- [x] ピンタップ5回に1回 → インタースティシャル → 店舗シート

投稿詳細
- [x] 閉じる → インタースティシャル → 前画面へ
- [x] 2投稿ごと → フィード内バナー
- [x] 検索ボタン → インタースティシャル → 外部URL

思い出アルバム
- [x] アルバムタップ → インタースティシャル → 詳細画面
- [x] 詳細画面下部 → 常時バナータブ切り替え

## 追加したPackage

- なし

## Screenshot
<img width="385" height="966" alt="IMG_3666" src="https://github.com/user-attachments/assets/200818ef-aa22-45d1-83a2-c48d76402076" />



|Before|After|
|:-:|:-:|
|<video src="https://github.com/user-attachments/assets/1e7b1a22-e6ff-4c38-a54c-b5ec8a2d729b">|<video src="https://github.com/user-attachments/assets/088ef102-46e7-491e-8582-0e13c81a15dd">|

|Before|After|After|
|:-:|:-:|:-:|
|<video src="https://github.com/user-attachments/assets/219f73a6-8f9a-4a8d-a78a-fd5812a51e54">|<video src="https://github.com/user-attachments/assets/470a9e6e-f541-4a32-994d-aef4b8481aec">|<video src="https://github.com/user-attachments/assets/5985db78-921a-422b-acdc-1aca9010c8d6">|







## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added banner and interstitial ads in several screens and flows, including map pins, memory albums, post details, and tab switching.
  * Introduced more consistent ad timing, such as showing ads after a set number of tab or pin taps.

* **Bug Fixes**
  * Improved ad display flow so screens open or close only after ads finish, reducing interrupted navigation.
  * Added safer handling for tap actions and screen closing to avoid unexpected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->