### PR TITLE
ダークモード中にマイページのAppBarの色がおかしくなる不具合を直しました

### DIFF
--- a/lib/ui/screen/profile/my_profile/my_profile_screen.dart
+++ b/lib/ui/screen/profile/my_profile/my_profile_screen.dart
@@ -46,8 +46,12 @@ class MyProfileScreen extends HookConsumerWidget {
           length: 2,
           child: Scaffold(
             appBar: AppBar(
-              surfaceTintColor: Colors.white,
-              backgroundColor: Colors.white,
+              backgroundColor: Theme.of(context).brightness == Brightness.light
+                  ? Colors.white
+                  : Theme.of(context).colorScheme.surface,
+              surfaceTintColor: Theme.of(context).brightness == Brightness.light
+                  ? Colors.white
+                  : Theme.of(context).colorScheme.surface,
               elevation: 0,
               centerTitle: true,
               leading: IconButton(


### PR DESCRIPTION
## Issue

- close #1175 

## 概要

- ダークモード中にマイページのAppBarの色がおかしくなる不具合を直しました

## 追加したPackage

- なし

## Screenshot

省略




## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the profile screen’s AppBar to adapt its background and tint colors to the selected light or dark theme.
  * Improved visual consistency in dark mode by replacing fixed white colors with theme-aware styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->