### PR TITLE
初めて開いた時に投稿のガイドを出現するようにしました

### DIFF
--- a/assets/i18n/strings_de.i18n.json
+++ b/assets/i18n/strings_de.i18n.json
@@ -954,5 +954,17 @@
     "minutesAgo": "vor {count} Min.",
     "hoursAgo": "vor {count} Std.",
     "daysAgo": "vor {count} T."
+  },
+  "firstPostGuide": {
+    "tapHint": "Tippe zum Starten!",
+    "promptTitle": "Halte dein erstes Gericht fest!",
+    "promptSubtitle": "Poste ein Foto und hinterlasse Erinnerungen auf der Karte",
+    "successTitle": "Beitrag fertig!",
+    "successSubtitle": "Zu deiner Food Map hinzugefügt",
+    "nextTitle": "Noch mehr Spaß!",
+    "nextSubtitle": "Erweitere deine Food-Reise",
+    "viewMap": "Karte ansehen",
+    "viewAlbum": "Album ansehen",
+    "seeLater": "Später ansehen"
   }
 }

--- a/assets/i18n/strings_en.i18n.json
+++ b/assets/i18n/strings_en.i18n.json
@@ -954,5 +954,17 @@
     "minutesAgo": "{count}m ago",
     "hoursAgo": "{count}h ago",
     "daysAgo": "{count}d ago"
+  },
+  "firstPostGuide": {
+    "tapHint": "Tap to get started!",
+    "promptTitle": "Record your first dish!",
+    "promptSubtitle": "Post a photo and leave memories on the map",
+    "successTitle": "Post complete!",
+    "successSubtitle": "Added to your Food Map",
+    "nextTitle": "Let's enjoy more!",
+    "nextSubtitle": "Expand your food journey",
+    "viewMap": "View Map",
+    "viewAlbum": "View Album",
+    "seeLater": "See later"
   }
 }

--- a/assets/i18n/strings_es.i18n.json
+++ b/assets/i18n/strings_es.i18n.json
@@ -954,5 +954,17 @@
     "minutesAgo": "hace {count} min",
     "hoursAgo": "hace {count} h",
     "daysAgo": "hace {count} d"
+  },
+  "firstPostGuide": {
+    "tapHint": "¡Toca para empezar!",
+    "promptTitle": "¡Registra tu primer plato!",
+    "promptSubtitle": "Publica una foto y deja recuerdos en el mapa",
+    "successTitle": "¡Publicación lista!",
+    "successSubtitle": "Se añadió a tu Food Map",
+    "nextTitle": "¡Disfruta más!",
+    "nextSubtitle": "Amplía tu viaje gastronómico",
+    "viewMap": "Ver mapa",
+    "viewAlbum": "Ver álbum",
+    "seeLater": "Ver más tarde"
   }
 }

--- a/assets/i18n/strings_fr.i18n.json
+++ b/assets/i18n/strings_fr.i18n.json
@@ -954,5 +954,17 @@
     "minutesAgo": "il y a {count} min",
     "hoursAgo": "il y a {count} h",
     "daysAgo": "il y a {count} j"
+  },
+  "firstPostGuide": {
+    "tapHint": "Appuyez pour commencer !",
+    "promptTitle": "Enregistrez votre premier plat !",
+    "promptSubtitle": "Publiez une photo et gardez des souvenirs sur la carte",
+    "successTitle": "Publication terminée !",
+    "successSubtitle": "Ajouté à votre Food Map",
+    "nextTitle": "Profitez encore plus !",
+    "nextSubtitle": "Élargissez votre voyage culinaire",
+    "viewMap": "Voir la carte",
+    "viewAlbum": "Voir l'album",
+    "seeLater": "Plus tard"
   }
 }

--- a/assets/i18n/strings_ja.i18n.json
+++ b/assets/i18n/strings_ja.i18n.json
@@ -954,5 +954,17 @@
     "minutesAgo": "{count}分前",
     "hoursAgo": "{count}時間前",
     "daysAgo": "{count}日前"
+  },
+  "firstPostGuide": {
+    "tapHint": "タップしてはじめよう！",
+    "promptTitle": "最初の一皿を記録しよう！",
+    "promptSubtitle": "写真を投稿すると地図に思い出が残ります",
+    "successTitle": "投稿完了！",
+    "successSubtitle": "あなたのFood Mapに追加されました",
+    "nextTitle": "もっと楽しもう！",
+    "nextSubtitle": "あなたの食の旅を広げていこう",
+    "viewMap": "地図を見る",
+    "viewAlbum": "アルバムを見る",
+    "seeLater": "あとで見る"
   }
 }

--- a/assets/i18n/strings_ko.i18n.json
+++ b/assets/i18n/strings_ko.i18n.json
@@ -954,5 +954,17 @@
     "minutesAgo": "{count}분 전",
     "hoursAgo": "{count}시간 전",
     "daysAgo": "{count}일 전"
+  },
+  "firstPostGuide": {
+    "tapHint": "탭해서 시작해요!",
+    "promptTitle": "첫 한 끼를 기록해 봐요!",
+    "promptSubtitle": "사진을 올리면 지도에 추억이 남아요",
+    "successTitle": "게시 완료!",
+    "successSubtitle": "나의 Food Map에 추가되었어요",
+    "nextTitle": "더 즐겨봐요!",
+    "nextSubtitle": "음식 여행을 더 넓혀 가요",
+    "viewMap": "지도 보기",
+    "viewAlbum": "앨범 보기",
+    "seeLater": "나중에 보기"
   }
 }

--- a/assets/i18n/strings_pt.i18n.json
+++ b/assets/i18n/strings_pt.i18n.json
@@ -954,5 +954,17 @@
     "minutesAgo": "há {count} min",
     "hoursAgo": "há {count} h",
     "daysAgo": "há {count} d"
+  },
+  "firstPostGuide": {
+    "tapHint": "Toque para começar!",
+    "promptTitle": "Registre seu primeiro prato!",
+    "promptSubtitle": "Poste uma foto e deixe memórias no mapa",
+    "successTitle": "Publicação concluída!",
+    "successSubtitle": "Adicionado ao seu Food Map",
+    "nextTitle": "Aproveite mais!",
+    "nextSubtitle": "Amplie sua jornada gastronômica",
+    "viewMap": "Ver mapa",
+    "viewAlbum": "Ver álbum",
+    "seeLater": "Ver depois"
   }
 }

--- a/assets/i18n/strings_th.i18n.json
+++ b/assets/i18n/strings_th.i18n.json
@@ -954,5 +954,17 @@
     "minutesAgo": "{count} นาทีที่แล้ว",
     "hoursAgo": "{count} ชั่วโมงที่แล้ว",
     "daysAgo": "{count} วันที่แล้ว"
+  },
+  "firstPostGuide": {
+    "tapHint": "แตะเพื่อเริ่มต้น!",
+    "promptTitle": "บันทึกจานแรกของคุณ!",
+    "promptSubtitle": "โพสต์รูปแล้วความทรงจำจะอยู่บนแผนที่",
+    "successTitle": "โพสต์สำเร็จ!",
+    "successSubtitle": "เพิ่มลง Food Map ของคุณแล้ว",
+    "nextTitle": "สนุกกันต่อเถอะ!",
+    "nextSubtitle": "ขยายการเดินทางด้านอาหารของคุณ",
+    "viewMap": "ดูแผนที่",
+    "viewAlbum": "ดูอัลบั้ม",
+    "seeLater": "ดูทีหลัง"
   }
 }

--- a/assets/i18n/strings_vi.i18n.json
+++ b/assets/i18n/strings_vi.i18n.json
@@ -954,5 +954,17 @@
     "minutesAgo": "{count} phút trước",
     "hoursAgo": "{count} giờ trước",
     "daysAgo": "{count} ngày trước"
+  },
+  "firstPostGuide": {
+    "tapHint": "Chạm để bắt đầu!",
+    "promptTitle": "Ghi lại món đầu tiên nào!",
+    "promptSubtitle": "Đăng ảnh để lưu kỷ niệm trên bản đồ",
+    "successTitle": "Đăng thành công!",
+    "successSubtitle": "Đã thêm vào Food Map của bạn",
+    "nextTitle": "Cùng vui hơn nữa!",
+    "nextSubtitle": "Mở rộng hành trình ẩm thực của bạn",
+    "viewMap": "Xem bản đồ",
+    "viewAlbum": "Xem album",
+    "seeLater": "Xem sau"
   }
 }

--- a/assets/i18n/strings_zh.i18n.json
+++ b/assets/i18n/strings_zh.i18n.json
@@ -954,5 +954,17 @@
     "minutesAgo": "{count}分钟前",
     "hoursAgo": "{count}小时前",
     "daysAgo": "{count}天前"
+  },
+  "firstPostGuide": {
+    "tapHint": "点击开始吧！",
+    "promptTitle": "记录你的第一道菜！",
+    "promptSubtitle": "发布照片，把回忆留在地图上",
+    "successTitle": "发布完成！",
+    "successSubtitle": "已添加到你的 Food Map",
+    "nextTitle": "一起玩得更开心！",
+    "nextSubtitle": "继续拓展你的美食之旅",
+    "viewMap": "查看地图",
+    "viewAlbum": "查看相册",
+    "seeLater": "稍后再看"
   }
 }

--- a/assets/i18n/strings_zh_TW.i18n.json
+++ b/assets/i18n/strings_zh_TW.i18n.json
@@ -954,5 +954,17 @@
     "minutesAgo": "{count}分鐘前",
     "hoursAgo": "{count}小時前",
     "daysAgo": "{count}天前"
+  },
+  "firstPostGuide": {
+    "tapHint": "點一下開始吧！",
+    "promptTitle": "記錄你的第一道菜！",
+    "promptSubtitle": "發布照片，把回憶留在地圖上",
+    "successTitle": "發布完成！",
+    "successSubtitle": "已加到你的 Food Map",
+    "nextTitle": "一起玩得更開心！",
+    "nextSubtitle": "繼續拓展你的美食之旅",
+    "viewMap": "查看地圖",
+    "viewAlbum": "查看相簿",
+    "seeLater": "稍後再看"
   }
 }

--- a/lib/core/analytics/analytics_event.dart
+++ b/lib/core/analytics/analytics_event.dart
@@ -13,6 +13,17 @@ abstract final class AnalyticsEvent {
   // --- チュートリアル ---
   static const String tutorialStart = 'tutorial_start';
   static const String tutorialComplete = 'tutorial_complete';
+  static const String firstPostGuideShow = 'first_post_guide_show';
+  static const String firstPostGuideTap = 'first_post_guide_tap';
+  static const String firstPostGuideDismiss = 'first_post_guide_dismiss';
+  static const String firstPostSuccessGuideShow =
+      'first_post_success_guide_show';
+  static const String firstPostSuccessGuideMap =
+      'first_post_success_guide_map';
+  static const String firstPostSuccessGuideAlbum =
+      'first_post_success_guide_album';
+  static const String firstPostSuccessGuideLater =
+      'first_post_success_guide_later';
 
   // --- タイムライン (Food) ---
   static const String timelineOpen = 'timeline_open';

--- a/lib/core/guide/first_post_guide_gate.dart
+++ b/lib/core/guide/first_post_guide_gate.dart
@@ -1,0 +1,50 @@
+import 'package:food_gram_app/core/local/shared_preference.dart';
+
+/// デバッグ用の強制表示。
+/// 確認したいときは `true` にする（本番では必ず `false` のまま）。
+const bool debugForceFirstPostGuide = false;
+
+/// 投稿ボタンへの初回誘導ガイドを表示すべきか。
+Future<bool> shouldShowFirstPostGuide({
+  required int postCount,
+  Preference? preference,
+}) async {
+  if (debugForceFirstPostGuide) {
+    return true;
+  }
+  if (postCount > 0) {
+    return false;
+  }
+  final prefs = preference ?? Preference();
+  final hasSeen = await prefs.getBool(PreferenceKey.hasSeenFirstPostGuide);
+  return !hasSeen;
+}
+
+Future<void> markFirstPostGuideShown({Preference? preference}) async {
+  if (debugForceFirstPostGuide) {
+    return;
+  }
+  final prefs = preference ?? Preference();
+  await prefs.setBool(PreferenceKey.hasSeenFirstPostGuide);
+}
+
+/// 初回投稿完了後のガイドを表示すべきか。
+Future<bool> shouldShowFirstPostSuccessGuide({
+  Preference? preference,
+}) async {
+  if (debugForceFirstPostGuide) {
+    return true;
+  }
+  final prefs = preference ?? Preference();
+  final hasSeen =
+      await prefs.getBool(PreferenceKey.hasSeenFirstPostSuccessGuide);
+  return !hasSeen;
+}
+
+Future<void> markFirstPostSuccessGuideShown({Preference? preference}) async {
+  if (debugForceFirstPostGuide) {
+    return;
+  }
+  final prefs = preference ?? Preference();
+  await prefs.setBool(PreferenceKey.hasSeenFirstPostSuccessGuide);
+}

--- a/lib/core/guide/first_post_guide_gate.dart
+++ b/lib/core/guide/first_post_guide_gate.dart
@@ -29,11 +29,17 @@ Future<void> markFirstPostGuideShown({Preference? preference}) async {
 }
 
 /// 初回投稿完了後のガイドを表示すべきか。
+///
+/// [previousPostCount] は投稿前の件数。0 以外なら出さない。
 Future<bool> shouldShowFirstPostSuccessGuide({
+  required int previousPostCount,
   Preference? preference,
 }) async {
   if (debugForceFirstPostGuide) {
     return true;
+  }
+  if (previousPostCount > 0) {
+    return false;
   }
   final prefs = preference ?? Preference();
   final hasSeen =

--- a/lib/core/local/shared_preference.dart
+++ b/lib/core/local/shared_preference.dart
@@ -28,6 +28,8 @@ enum PreferenceKey {
   lastWeeklySummaryWeekStart,
   lastMonthlySummaryMonthStart,
   wantToGoList,
+  hasSeenFirstPostGuide,
+  hasSeenFirstPostSuccessGuide,
 }
 
 class Preference {

--- a/lib/ui/component/app_text_field.dart
+++ b/lib/ui/component/app_text_field.dart
@@ -315,6 +315,8 @@ class AppNameTextField extends StatelessWidget {
                   selectionHeightStyle: BoxHeightStyle.strut,
                   decoration: InputDecoration(
                     border: InputBorder.none,
+                    enabledBorder: InputBorder.none,
+                    focusedBorder: InputBorder.none,
                     contentPadding: const EdgeInsets.symmetric(
                       horizontal: 12,
                       vertical: 12,
@@ -384,6 +386,8 @@ class AppSelfIntroductionTextField extends StatelessWidget {
                   decoration: InputDecoration(
                     floatingLabelBehavior: FloatingLabelBehavior.always,
                     border: InputBorder.none,
+                    enabledBorder: InputBorder.none,
+                    focusedBorder: InputBorder.none,
                     contentPadding: const EdgeInsets.symmetric(
                       horizontal: 12,
                       vertical: 12,

--- a/lib/ui/component/guide/first_post_guide_overlay.dart
+++ b/lib/ui/component/guide/first_post_guide_overlay.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:food_gram_app/core/theme/app_theme.dart';
 import 'package:food_gram_app/gen/strings.g.dart';
 import 'package:gap/gap.dart';
@@ -8,7 +10,7 @@ import 'package:gap/gap.dart';
 /// 投稿 FAB への初回誘導オーバーレイ。
 ///
 /// 発光する投稿ボタン + 「タップしてはじめよう！」→ 吹き出し。
-class FirstPostGuideOverlay extends StatefulWidget {
+class FirstPostGuideOverlay extends HookWidget {
   const FirstPostGuideOverlay({
     required this.buttonKey,
     required this.onTapPost,
@@ -21,88 +23,95 @@ class FirstPostGuideOverlay extends StatefulWidget {
   final VoidCallback onDismiss;
 
   @override
-  State<FirstPostGuideOverlay> createState() => _FirstPostGuideOverlayState();
-}
-
-class _FirstPostGuideOverlayState extends State<FirstPostGuideOverlay>
-    with TickerProviderStateMixin {
-  late final AnimationController _pulseController;
-  late final AnimationController _bubbleController;
-  Rect? _buttonRect;
-
-  @override
-  void initState() {
-    super.initState();
-    _pulseController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 1400),
-    )..repeat(reverse: true);
-    _bubbleController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 450),
-    );
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _updateButtonRect();
-      Future<void>.delayed(const Duration(milliseconds: 900), () {
-        if (mounted) {
-          _bubbleController.forward();
-        }
-      });
-    });
-  }
-
-  @override
-  void dispose() {
-    _pulseController.dispose();
-    _bubbleController.dispose();
-    super.dispose();
-  }
-
-  void _updateButtonRect() {
-    final buttonContext = widget.buttonKey.currentContext;
-    if (buttonContext == null || !mounted) {
-      return;
-    }
-    final box = buttonContext.findRenderObject() as RenderBox?;
-    final overlayBox = context.findRenderObject() as RenderBox?;
-    if (box == null || !box.hasSize || overlayBox == null) {
-      return;
-    }
-    final globalOffset = box.localToGlobal(Offset.zero);
-    final localOffset = overlayBox.globalToLocal(globalOffset);
-    setState(() {
-      _buttonRect = localOffset & box.size;
-    });
-  }
-
-  @override
   Widget build(BuildContext context) {
     final translations = Translations.of(context);
-    final buttonRect = _buttonRect;
-    if (buttonRect == null) {
-      // 初回フレームでサイズを取るため、領域だけ確保する
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) {
-          _updateButtonRect();
+    final buttonRect = useState<Rect?>(null);
+    final overlayKey = useMemoized(GlobalKey.new);
+
+    final pulseController = useAnimationController(
+      duration: const Duration(milliseconds: 1400),
+    );
+    final bubbleController = useAnimationController(
+      duration: const Duration(milliseconds: 450),
+    );
+
+    void updateButtonRect() {
+      final buttonContext = buttonKey.currentContext;
+      final overlayContext = overlayKey.currentContext;
+      if (buttonContext == null || overlayContext == null) {
+        return;
+      }
+      final box = buttonContext.findRenderObject() as RenderBox?;
+      final overlayBox = overlayContext.findRenderObject() as RenderBox?;
+      if (box == null || !box.hasSize || overlayBox == null) {
+        return;
+      }
+      final globalOffset = box.localToGlobal(Offset.zero);
+      final localOffset = overlayBox.globalToLocal(globalOffset);
+      buttonRect.value = localOffset & box.size;
+    }
+
+    useEffect(
+      () {
+        pulseController.repeat(reverse: true);
+        var cancelled = false;
+        Timer? bubbleTimer;
+
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (cancelled) {
+            return;
+          }
+          updateButtonRect();
+          bubbleTimer = Timer(const Duration(milliseconds: 900), () {
+            if (!cancelled) {
+              bubbleController.forward();
+            }
+          });
+        });
+
+        return () {
+          cancelled = true;
+          bubbleTimer?.cancel();
+        };
+      },
+      [pulseController, bubbleController],
+    );
+
+    // FAB 座標が取れるまで再計測
+    useEffect(
+      () {
+        if (buttonRect.value != null) {
+          return null;
         }
-      });
-      return const Material(
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          updateButtonRect();
+        });
+        return null;
+      },
+      [buttonRect.value],
+    );
+
+    final rect = buttonRect.value;
+    if (rect == null) {
+      return Material(
+        key: overlayKey,
         type: MaterialType.transparency,
-        child: SizedBox.expand(),
+        child: const SizedBox.expand(),
       );
     }
 
-    final center = buttonRect.center;
-    final holeRadius = buttonRect.width / 2 + 10;
+    final center = rect.center;
+    final holeRadius = rect.width / 2 + 10;
 
     return Material(
+      key: overlayKey,
       type: MaterialType.transparency,
       child: Stack(
         children: [
           Positioned.fill(
             child: GestureDetector(
               behavior: HitTestBehavior.opaque,
-              onTap: widget.onDismiss,
+              onTap: onDismiss,
               child: CustomPaint(
                 painter: _HoleMaskPainter(
                   holeCenter: center,
@@ -112,9 +121,9 @@ class _FirstPostGuideOverlayState extends State<FirstPostGuideOverlay>
             ),
           ),
           AnimatedBuilder(
-            animation: _pulseController,
+            animation: pulseController,
             builder: (context, child) {
-              final pulse = Curves.easeInOut.transform(_pulseController.value);
+              final pulse = Curves.easeInOut.transform(pulseController.value);
               final scale = 1.0 + pulse * 0.35;
               final opacity = 0.55 - pulse * 0.35;
               return Positioned(
@@ -146,13 +155,13 @@ class _FirstPostGuideOverlayState extends State<FirstPostGuideOverlay>
             left: 24,
             right: 24,
             top: 0,
-            height: math.max(0, buttonRect.top - 16),
+            height: math.max(0, rect.top - 16),
             child: IgnorePointer(
               child: AnimatedBuilder(
-                animation: _bubbleController,
+                animation: bubbleController,
                 builder: (context, child) {
                   return Opacity(
-                    opacity: (1 - _bubbleController.value).clamp(0.0, 1.0),
+                    opacity: (1 - bubbleController.value).clamp(0.0, 1.0),
                     child: child,
                   );
                 },
@@ -168,17 +177,17 @@ class _FirstPostGuideOverlayState extends State<FirstPostGuideOverlay>
             left: 28,
             right: 28,
             top: 0,
-            height: math.max(0, buttonRect.top - 12),
+            height: math.max(0, rect.top - 12),
             child: IgnorePointer(
               child: FadeTransition(
-                opacity: _bubbleController,
+                opacity: bubbleController,
                 child: SlideTransition(
                   position: Tween<Offset>(
                     begin: const Offset(0, 0.12),
                     end: Offset.zero,
                   ).animate(
                     CurvedAnimation(
-                      parent: _bubbleController,
+                      parent: bubbleController,
                       curve: Curves.easeOutCubic,
                     ),
                   ),
@@ -194,14 +203,14 @@ class _FirstPostGuideOverlayState extends State<FirstPostGuideOverlay>
             ),
           ),
           Positioned(
-            left: buttonRect.left,
-            top: buttonRect.top,
-            width: buttonRect.width,
-            height: buttonRect.height,
+            left: rect.left,
+            top: rect.top,
+            width: rect.width,
+            height: rect.height,
             child: Material(
               color: Colors.transparent,
               child: InkWell(
-                onTap: widget.onTapPost,
+                onTap: onTapPost,
                 customBorder: const CircleBorder(),
                 child: Ink(
                   decoration: const BoxDecoration(

--- a/lib/ui/component/guide/first_post_guide_overlay.dart
+++ b/lib/ui/component/guide/first_post_guide_overlay.dart
@@ -1,0 +1,394 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:food_gram_app/core/theme/app_theme.dart';
+import 'package:food_gram_app/gen/strings.g.dart';
+import 'package:gap/gap.dart';
+
+/// 投稿 FAB への初回誘導オーバーレイ。
+///
+/// 発光する投稿ボタン + 「タップしてはじめよう！」→ 吹き出し。
+class FirstPostGuideOverlay extends StatefulWidget {
+  const FirstPostGuideOverlay({
+    required this.buttonKey,
+    required this.onTapPost,
+    required this.onDismiss,
+    super.key,
+  });
+
+  final GlobalKey buttonKey;
+  final VoidCallback onTapPost;
+  final VoidCallback onDismiss;
+
+  @override
+  State<FirstPostGuideOverlay> createState() => _FirstPostGuideOverlayState();
+}
+
+class _FirstPostGuideOverlayState extends State<FirstPostGuideOverlay>
+    with TickerProviderStateMixin {
+  late final AnimationController _pulseController;
+  late final AnimationController _bubbleController;
+  Rect? _buttonRect;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1400),
+    )..repeat(reverse: true);
+    _bubbleController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 450),
+    );
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _updateButtonRect();
+      Future<void>.delayed(const Duration(milliseconds: 900), () {
+        if (mounted) {
+          _bubbleController.forward();
+        }
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _pulseController.dispose();
+    _bubbleController.dispose();
+    super.dispose();
+  }
+
+  void _updateButtonRect() {
+    final buttonContext = widget.buttonKey.currentContext;
+    if (buttonContext == null || !mounted) {
+      return;
+    }
+    final box = buttonContext.findRenderObject() as RenderBox?;
+    final overlayBox = context.findRenderObject() as RenderBox?;
+    if (box == null || !box.hasSize || overlayBox == null) {
+      return;
+    }
+    final globalOffset = box.localToGlobal(Offset.zero);
+    final localOffset = overlayBox.globalToLocal(globalOffset);
+    setState(() {
+      _buttonRect = localOffset & box.size;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final translations = Translations.of(context);
+    final buttonRect = _buttonRect;
+    if (buttonRect == null) {
+      // 初回フレームでサイズを取るため、領域だけ確保する
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          _updateButtonRect();
+        }
+      });
+      return const Material(
+        type: MaterialType.transparency,
+        child: SizedBox.expand(),
+      );
+    }
+
+    final center = buttonRect.center;
+    final holeRadius = buttonRect.width / 2 + 10;
+
+    return Material(
+      type: MaterialType.transparency,
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: widget.onDismiss,
+              child: CustomPaint(
+                painter: _HoleMaskPainter(
+                  holeCenter: center,
+                  holeRadius: holeRadius,
+                ),
+              ),
+            ),
+          ),
+          AnimatedBuilder(
+            animation: _pulseController,
+            builder: (context, child) {
+              final pulse = Curves.easeInOut.transform(_pulseController.value);
+              final scale = 1.0 + pulse * 0.35;
+              final opacity = 0.55 - pulse * 0.35;
+              return Positioned(
+                left: center.dx - holeRadius * scale,
+                top: center.dy - holeRadius * scale,
+                child: IgnorePointer(
+                  child: Container(
+                    width: holeRadius * 2 * scale,
+                    height: holeRadius * 2 * scale,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: const Color(0xFFFFD54F).withValues(alpha: opacity),
+                      boxShadow: [
+                        BoxShadow(
+                          color: const Color(0xFFFFC107)
+                              .withValues(alpha: opacity * 0.9),
+                          blurRadius: 24 + pulse * 16,
+                          spreadRadius: 4 + pulse * 8,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+          // Phase1: タップ誘導テキスト
+          Positioned(
+            left: 24,
+            right: 24,
+            top: 0,
+            height: math.max(0, buttonRect.top - 16),
+            child: IgnorePointer(
+              child: AnimatedBuilder(
+                animation: _bubbleController,
+                builder: (context, child) {
+                  return Opacity(
+                    opacity: (1 - _bubbleController.value).clamp(0.0, 1.0),
+                    child: child,
+                  );
+                },
+                child: const Align(
+                  alignment: Alignment.bottomCenter,
+                  child: _TapHint(),
+                ),
+              ),
+            ),
+          ),
+          // Phase2: 吹き出し
+          Positioned(
+            left: 28,
+            right: 28,
+            top: 0,
+            height: math.max(0, buttonRect.top - 12),
+            child: IgnorePointer(
+              child: FadeTransition(
+                opacity: _bubbleController,
+                child: SlideTransition(
+                  position: Tween<Offset>(
+                    begin: const Offset(0, 0.12),
+                    end: Offset.zero,
+                  ).animate(
+                    CurvedAnimation(
+                      parent: _bubbleController,
+                      curve: Curves.easeOutCubic,
+                    ),
+                  ),
+                  child: Align(
+                    alignment: Alignment.bottomCenter,
+                    child: _PromptBubble(
+                      title: translations.firstPostGuide.promptTitle,
+                      subtitle: translations.firstPostGuide.promptSubtitle,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            left: buttonRect.left,
+            top: buttonRect.top,
+            width: buttonRect.width,
+            height: buttonRect.height,
+            child: Material(
+              color: Colors.transparent,
+              child: InkWell(
+                onTap: widget.onTapPost,
+                customBorder: const CircleBorder(),
+                child: Ink(
+                  decoration: const BoxDecoration(
+                    color: AppTheme.primaryBlue,
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(
+                    Icons.add,
+                    size: 32,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TapHint extends StatelessWidget {
+  const _TapHint();
+
+  @override
+  Widget build(BuildContext context) {
+    final translations = Translations.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          translations.firstPostGuide.tapHint,
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: 22,
+            fontWeight: FontWeight.w800,
+            letterSpacing: 0.5,
+            shadows: [
+              Shadow(
+                color: Colors.black.withValues(alpha: 0.45),
+                blurRadius: 8,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+        ),
+        const Gap(4),
+        Icon(
+          Icons.arrow_downward_rounded,
+          color: Colors.white.withValues(alpha: 0.95),
+          size: 28,
+          shadows: [
+            Shadow(
+              color: Colors.black.withValues(alpha: 0.4),
+              blurRadius: 6,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _PromptBubble extends StatelessWidget {
+  const _PromptBubble({
+    required this.title,
+    required this.subtitle,
+  });
+
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.fromLTRB(20, 20, 20, 18),
+          decoration: BoxDecoration(
+            color: colorScheme.surface,
+            borderRadius: BorderRadius.circular(20),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.18),
+                blurRadius: 20,
+                offset: const Offset(0, 8),
+              ),
+            ],
+          ),
+          child: Column(
+            children: [
+              Container(
+                width: 48,
+                height: 48,
+                decoration: BoxDecoration(
+                  color: AppTheme.primaryBlue.withValues(alpha: 0.12),
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(
+                  Icons.camera_alt_rounded,
+                  color: AppTheme.primaryBlue,
+                  size: 26,
+                ),
+              ),
+              const Gap(12),
+              Text(
+                title,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+              const Gap(8),
+              Text(
+                subtitle,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 14,
+                  height: 1.4,
+                  color: colorScheme.onSurface.withValues(alpha: 0.7),
+                ),
+              ),
+            ],
+          ),
+        ),
+        CustomPaint(
+          size: const Size(18, 10),
+          painter: _BubbleTailPainter(color: colorScheme.surface),
+        ),
+      ],
+    );
+  }
+}
+
+class _BubbleTailPainter extends CustomPainter {
+  _BubbleTailPainter({required this.color});
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final path = Path()
+      ..moveTo(0, 0)
+      ..lineTo(size.width / 2, size.height)
+      ..lineTo(size.width, 0)
+      ..close();
+    canvas.drawPath(path, Paint()..color = color);
+  }
+
+  @override
+  bool shouldRepaint(covariant _BubbleTailPainter oldDelegate) {
+    return oldDelegate.color != color;
+  }
+}
+
+class _HoleMaskPainter extends CustomPainter {
+  _HoleMaskPainter({
+    required this.holeCenter,
+    required this.holeRadius,
+  });
+
+  final Offset holeCenter;
+  final double holeRadius;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final overlay = Path()..addRect(Offset.zero & size);
+    final hole = Path()
+      ..addOval(
+        Rect.fromCircle(center: holeCenter, radius: holeRadius),
+      );
+    final path = Path.combine(PathOperation.difference, overlay, hole);
+    canvas.drawPath(
+      path,
+      Paint()..color = Colors.black.withValues(alpha: 0.55),
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _HoleMaskPainter oldDelegate) {
+    return oldDelegate.holeCenter != holeCenter ||
+        oldDelegate.holeRadius != holeRadius;
+  }
+}

--- a/lib/ui/component/guide/first_post_success_dialog.dart
+++ b/lib/ui/component/guide/first_post_success_dialog.dart
@@ -70,8 +70,9 @@ class _FirstPostCompleteDialog extends ConsumerWidget {
     }
 
     final restaurant = post?.restaurant.trim() ?? '';
+    final localeTag = Localizations.localeOf(context).toLanguageTag();
     final dateLabel = post != null
-        ? DateFormat('yyyy/M/d').format(post!.createdAt.toLocal())
+        ? DateFormat.yMd(localeTag).format(post!.createdAt.toLocal())
         : '';
 
     return Dialog(

--- a/lib/ui/component/guide/first_post_success_dialog.dart
+++ b/lib/ui/component/guide/first_post_success_dialog.dart
@@ -1,0 +1,325 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:food_gram_app/core/model/posts.dart';
+import 'package:food_gram_app/core/supabase/current_user_provider.dart';
+import 'package:food_gram_app/core/theme/app_theme.dart';
+import 'package:food_gram_app/gen/assets.gen.dart';
+import 'package:food_gram_app/gen/strings.g.dart';
+import 'package:gap/gap.dart';
+import 'package:intl/intl.dart';
+
+enum FirstPostSuccessAction {
+  viewMap,
+  viewAlbum,
+  later,
+}
+
+/// 初回投稿完了 → 次アクション誘導の一連ダイアログ。
+Future<FirstPostSuccessAction?> showFirstPostSuccessGuide({
+  required BuildContext context,
+  Posts? post,
+}) async {
+  final t = Translations.of(context);
+
+  await showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    builder: (context) {
+      return _FirstPostCompleteDialog(post: post, t: t);
+    },
+  );
+
+  if (!context.mounted) {
+    return null;
+  }
+
+  return showDialog<FirstPostSuccessAction>(
+    context: context,
+    barrierDismissible: false,
+    builder: (context) {
+      return _FirstPostNextActionDialog(t: t);
+    },
+  );
+}
+
+class _FirstPostCompleteDialog extends ConsumerWidget {
+  const _FirstPostCompleteDialog({
+    required this.post,
+    required this.t,
+  });
+
+  final Posts? post;
+  final Translations t;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final deviceWidth = MediaQuery.sizeOf(context).width;
+
+    String? imageUrl;
+    final storageKey = post?.firstFoodImage ?? '';
+    if (storageKey.isNotEmpty) {
+      imageUrl = ref
+          .read(supabaseProvider)
+          .storage
+          .from('food')
+          .getPublicUrl(storageKey);
+    }
+
+    final restaurant = post?.restaurant.trim() ?? '';
+    final dateLabel = post != null
+        ? DateFormat('yyyy/M/d').format(post!.createdAt.toLocal())
+        : '';
+
+    return Dialog(
+      backgroundColor: colorScheme.surface,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      child: SizedBox(
+        width: deviceWidth * 0.85,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 28, 20, 12),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('🎉', style: TextStyle(fontSize: 40)),
+              const Gap(12),
+              Text(
+                t.firstPostGuide.successTitle,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+              const Gap(8),
+              Text(
+                t.firstPostGuide.successSubtitle,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 14,
+                  height: 1.4,
+                  color: colorScheme.onSurface.withValues(alpha: 0.7),
+                ),
+              ),
+              if (post != null) ...[
+                const Gap(20),
+                Container(
+                  padding: const EdgeInsets.all(10),
+                  decoration: BoxDecoration(
+                    color: isDark
+                        ? colorScheme.surfaceContainerHighest
+                        : const Color(0xFFF7F7F7),
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  child: Row(
+                    children: [
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(10),
+                        child: SizedBox(
+                          width: 64,
+                          height: 64,
+                          child: imageUrl == null || imageUrl.isEmpty
+                              ? ColoredBox(
+                                  color: isDark
+                                      ? Colors.grey.shade800
+                                      : Colors.grey.shade200,
+                                )
+                              : CachedNetworkImage(
+                                  imageUrl: imageUrl,
+                                  fit: BoxFit.cover,
+                                  errorWidget: (context, url, error) {
+                                    return Image.asset(
+                                      isDark
+                                          ? Assets.image.emptyDark.path
+                                          : Assets.image.empty.path,
+                                      fit: BoxFit.cover,
+                                    );
+                                  },
+                                ),
+                        ),
+                      ),
+                      const Gap(12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              restaurant.isEmpty
+                                  ? post!.foodName
+                                  : restaurant,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                fontSize: 15,
+                                fontWeight: FontWeight.w600,
+                                color: colorScheme.onSurface,
+                              ),
+                            ),
+                            if (dateLabel.isNotEmpty) ...[
+                              const Gap(4),
+                              Text(
+                                dateLabel,
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: colorScheme.onSurface
+                                      .withValues(alpha: 0.55),
+                                ),
+                              ),
+                            ],
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+              const Gap(8),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                style: TextButton.styleFrom(
+                  foregroundColor: AppTheme.primaryBlue,
+                ),
+                child: Text(
+                  t.close,
+                  style: const TextStyle(
+                    fontSize: 17,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FirstPostNextActionDialog extends StatelessWidget {
+  const _FirstPostNextActionDialog({required this.t});
+
+  final Translations t;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final deviceWidth = MediaQuery.sizeOf(context).width;
+
+    return Dialog(
+      backgroundColor: colorScheme.surface,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      child: SizedBox(
+        width: deviceWidth * 0.85,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 28, 20, 16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                t.firstPostGuide.nextTitle,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+              const Gap(8),
+              Text(
+                t.firstPostGuide.nextSubtitle,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 14,
+                  height: 1.4,
+                  color: colorScheme.onSurface.withValues(alpha: 0.7),
+                ),
+              ),
+              const Gap(20),
+              _ActionTile(
+                icon: CupertinoIcons.map,
+                label: t.firstPostGuide.viewMap,
+                onTap: () => Navigator.of(context)
+                    .pop(FirstPostSuccessAction.viewMap),
+              ),
+              const Gap(10),
+              _ActionTile(
+                icon: CupertinoIcons.book,
+                label: t.firstPostGuide.viewAlbum,
+                onTap: () => Navigator.of(context)
+                    .pop(FirstPostSuccessAction.viewAlbum),
+              ),
+              const Gap(8),
+              TextButton(
+                onPressed: () =>
+                    Navigator.of(context).pop(FirstPostSuccessAction.later),
+                child: Text(
+                  t.firstPostGuide.seeLater,
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: colorScheme.onSurface.withValues(alpha: 0.55),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ActionTile extends StatelessWidget {
+  const _ActionTile({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Material(
+      color: isDark
+          ? colorScheme.surfaceContainerHighest
+          : const Color(0xFFF5F5F5),
+      borderRadius: BorderRadius.circular(14),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(14),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          child: Row(
+            children: [
+              Icon(icon, color: AppTheme.primaryBlue, size: 22),
+              const Gap(12),
+              Expanded(
+                child: Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                    color: colorScheme.onSurface,
+                  ),
+                ),
+              ),
+              Icon(
+                Icons.chevron_right,
+                color: colorScheme.onSurface.withValues(alpha: 0.35),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/screen/tab/tab_screen.dart
+++ b/lib/ui/screen/tab/tab_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:food_gram_app/core/analytics/analytics_event.dart';
 import 'package:food_gram_app/core/analytics/firebase_analytics_service.dart';
 import 'package:food_gram_app/core/guide/first_post_guide_gate.dart';
+import 'package:food_gram_app/core/model/posts.dart';
 import 'package:food_gram_app/core/summary/summary_launch_gate.dart';
 import 'package:food_gram_app/core/supabase/current_user_provider.dart';
 import 'package:food_gram_app/core/supabase/post/providers/block_list_provider.dart';
@@ -128,7 +129,11 @@ class TabScreen extends HookConsumerWidget {
 
     Future<void> dismissFirstPostGuide({required bool tappedPost}) async {
       showFirstPostGuide.value = false;
-      await markFirstPostGuideShown();
+      try {
+        await markFirstPostGuideShown();
+      } on Object {
+        // 既読保存失敗でも analytics / 投稿導線は続行する
+      }
       final analytics = ref.read(firebaseAnalyticsServiceProvider);
       analytics.logEventUnawaited(
         name: tappedPost
@@ -145,9 +150,16 @@ class TabScreen extends HookConsumerWidget {
             );
       }
 
-      final oldPostCount =
-          ref.read(myPostStreamProvider).valueOrNull?.length ?? 0;
-      final isFirstPost = oldPostCount == 0;
+      // valueOrNull ?? 0 だと loading 中に「初回投稿」と誤判定されるため、
+      // future で確定件数を取る。失敗時は初回扱いしない。
+      int? previousPostCount;
+      try {
+        previousPostCount =
+            (await ref.read(myPostStreamProvider.future)).length;
+      } on Object {
+        previousPostCount = null;
+      }
+      final isFirstPost = previousPostCount == 0;
       final result = await context.pushNamed(RouterPath.timeLinePost);
       if (result == null || !context.mounted) {
         return;
@@ -173,44 +185,45 @@ class TabScreen extends HookConsumerWidget {
             ref.invalidate(postCountRankProvider(uid));
           }
           // 初回投稿完了ガイドがある場合はレベルアップ演出と重ねない
-          if (!isFirstPost) {
+          if (!isFirstPost && previousPostCount != null) {
             try {
-              await ref.read(myPostStreamProvider.future);
+              final refreshedPosts =
+                  await ref.read(myPostStreamProvider.future);
+              final newPostCount = refreshedPosts.length;
+              if (UserLevel.levelFromPostCount(newPostCount) >
+                      UserLevel.levelFromPostCount(previousPostCount) &&
+                  context.mounted) {
+                await showLevelUpDialog(
+                  context: context,
+                  level: UserLevel.levelFromPostCount(newPostCount),
+                );
+              }
             } on Object {
               // 再取得失敗時はレベルアップ判定をスキップ
-              break;
-            }
-            final newPostCount =
-                ref.read(myPostStreamProvider).valueOrNull?.length ?? 0;
-            if (UserLevel.levelFromPostCount(newPostCount) >
-                    UserLevel.levelFromPostCount(oldPostCount) &&
-                context.mounted) {
-              await showLevelUpDialog(
-                context: context,
-                level: UserLevel.levelFromPostCount(newPostCount),
-              );
             }
           }
       }
 
       // 初回投稿完了ガイド（ストリーク等のあとに Tab へ戻ってから表示）
       if (isFirstPost && context.mounted) {
-        final shouldShow = await shouldShowFirstPostSuccessGuide();
+        final shouldShow = await shouldShowFirstPostSuccessGuide(
+          previousPostCount: 0,
+        );
         if (!shouldShow || !context.mounted) {
           return;
         }
         // 最新投稿を取得してプレビューに使う
         ref.invalidate(myPostStreamProvider);
+        Posts? latestPost;
         try {
-          await ref.read(myPostStreamProvider.future);
+          final posts = await ref.read(myPostStreamProvider.future);
+          latestPost = posts.isEmpty ? null : posts.last;
         } on Object {
           // プレビューなしでもガイドは出す
         }
         if (!context.mounted) {
           return;
         }
-        final posts = ref.read(myPostStreamProvider).valueOrNull;
-        final latestPost = posts == null || posts.isEmpty ? null : posts.last;
         ref.read(firebaseAnalyticsServiceProvider).logEventUnawaited(
               name: AnalyticsEvent.firstPostSuccessGuideShow,
             );
@@ -218,7 +231,11 @@ class TabScreen extends HookConsumerWidget {
           context: context,
           post: latestPost,
         );
-        await markFirstPostSuccessGuideShown();
+        try {
+          await markFirstPostSuccessGuideShown();
+        } on Object {
+          // 既読保存失敗でも地図/アルバム導線は続行する
+        }
         if (!context.mounted || action == null) {
           return;
         }

--- a/lib/ui/screen/tab/tab_screen.dart
+++ b/lib/ui/screen/tab/tab_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:food_gram_app/core/analytics/analytics_event.dart';
 import 'package:food_gram_app/core/analytics/firebase_analytics_service.dart';
+import 'package:food_gram_app/core/guide/first_post_guide_gate.dart';
 import 'package:food_gram_app/core/summary/summary_launch_gate.dart';
 import 'package:food_gram_app/core/supabase/current_user_provider.dart';
 import 'package:food_gram_app/core/supabase/post/providers/block_list_provider.dart';
@@ -18,6 +19,8 @@ import 'package:food_gram_app/core/utils/user_level.dart';
 import 'package:food_gram_app/gen/strings.g.dart';
 import 'package:food_gram_app/router/router.dart';
 import 'package:food_gram_app/ui/component/dialog/app_level_up_dialog.dart';
+import 'package:food_gram_app/ui/component/guide/first_post_guide_overlay.dart';
+import 'package:food_gram_app/ui/component/guide/first_post_success_dialog.dart';
 import 'package:food_gram_app/ui/screen/tab/tab_view_model.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
@@ -67,6 +70,8 @@ class TabScreen extends HookConsumerWidget {
     final state = ref.watch(tabViewModelProvider());
     final controller = ref.watch(tabViewModelProvider().notifier);
     final t = Translations.of(context);
+    final postButtonKey = useMemoized(GlobalKey.new);
+    final showFirstPostGuide = useState(false);
 
     useEffect(
       () {
@@ -85,16 +90,33 @@ class TabScreen extends HookConsumerWidget {
               now: now,
               posts: posts,
             );
-            if (launchType == null || cancelled || !context.mounted) {
+            if (launchType != null) {
+              if (cancelled || !context.mounted) {
+                return;
+              }
+              await context.pushNamed(_routeNameForSummary(launchType));
+              // 表示（プッシュ→ポップ）に成功したときだけ「表示済み」を記録する。
+              // pushNamed が失敗した場合は例外で下の catch に飛ぶため、
+              // 未表示のまま既読扱いになることを防げる。
+              await markSummaryLaunchShown(type: launchType, now: now);
+            }
+
+            // まとめ表示のあとに、初回投稿ガイドを判定する
+            if (cancelled || !context.mounted) {
               return;
             }
-            await context.pushNamed(_routeNameForSummary(launchType));
-            // 表示（プッシュ→ポップ）に成功したときだけ「表示済み」を記録する。
-            // pushNamed が失敗した場合は例外で下の catch に飛ぶため、
-            // 未表示のまま既読扱いになることを防げる。
-            await markSummaryLaunchShown(type: launchType, now: now);
+            final shouldShow = await shouldShowFirstPostGuide(
+              postCount: posts.length,
+            );
+            if (cancelled || !context.mounted || !shouldShow) {
+              return;
+            }
+            showFirstPostGuide.value = true;
+            ref.read(firebaseAnalyticsServiceProvider).logEventUnawaited(
+                  name: AnalyticsEvent.firstPostGuideShow,
+                );
           } on Object {
-            // 起動時のまとめ表示失敗は無視
+            // 起動時のまとめ・ガイド表示失敗は無視
           }
         });
         return () {
@@ -103,6 +125,17 @@ class TabScreen extends HookConsumerWidget {
       },
       const [],
     );
+
+    Future<void> dismissFirstPostGuide({required bool tappedPost}) async {
+      showFirstPostGuide.value = false;
+      await markFirstPostGuideShown();
+      final analytics = ref.read(firebaseAnalyticsServiceProvider);
+      analytics.logEventUnawaited(
+        name: tappedPost
+            ? AnalyticsEvent.firstPostGuideTap
+            : AnalyticsEvent.firstPostGuideDismiss,
+      );
+    }
 
     Future<void> onPostPressed() async {
       final selectedIndex = state.selectedIndex;
@@ -114,6 +147,7 @@ class TabScreen extends HookConsumerWidget {
 
       final oldPostCount =
           ref.read(myPostStreamProvider).valueOrNull?.length ?? 0;
+      final isFirstPost = oldPostCount == 0;
       final result = await context.pushNamed(RouterPath.timeLinePost);
       if (result == null || !context.mounted) {
         return;
@@ -138,159 +172,231 @@ class TabScreen extends HookConsumerWidget {
           if (uid != null) {
             ref.invalidate(postCountRankProvider(uid));
           }
-          try {
-            await ref.read(myPostStreamProvider.future);
-          } on Object {
-            // 再取得失敗時はレベルアップ判定をスキップ
-            return;
+          // 初回投稿完了ガイドがある場合はレベルアップ演出と重ねない
+          if (!isFirstPost) {
+            try {
+              await ref.read(myPostStreamProvider.future);
+            } on Object {
+              // 再取得失敗時はレベルアップ判定をスキップ
+              break;
+            }
+            final newPostCount =
+                ref.read(myPostStreamProvider).valueOrNull?.length ?? 0;
+            if (UserLevel.levelFromPostCount(newPostCount) >
+                    UserLevel.levelFromPostCount(oldPostCount) &&
+                context.mounted) {
+              await showLevelUpDialog(
+                context: context,
+                level: UserLevel.levelFromPostCount(newPostCount),
+              );
+            }
           }
-          final newPostCount =
-              ref.read(myPostStreamProvider).valueOrNull?.length ?? 0;
-          if (UserLevel.levelFromPostCount(newPostCount) >
-                  UserLevel.levelFromPostCount(oldPostCount) &&
-              context.mounted) {
-            await showLevelUpDialog(
-              context: context,
-              level: UserLevel.levelFromPostCount(newPostCount),
+      }
+
+      // 初回投稿完了ガイド（ストリーク等のあとに Tab へ戻ってから表示）
+      if (isFirstPost && context.mounted) {
+        final shouldShow = await shouldShowFirstPostSuccessGuide();
+        if (!shouldShow || !context.mounted) {
+          return;
+        }
+        // 最新投稿を取得してプレビューに使う
+        ref.invalidate(myPostStreamProvider);
+        try {
+          await ref.read(myPostStreamProvider.future);
+        } on Object {
+          // プレビューなしでもガイドは出す
+        }
+        if (!context.mounted) {
+          return;
+        }
+        final posts = ref.read(myPostStreamProvider).valueOrNull;
+        final latestPost = posts == null || posts.isEmpty ? null : posts.last;
+        ref.read(firebaseAnalyticsServiceProvider).logEventUnawaited(
+              name: AnalyticsEvent.firstPostSuccessGuideShow,
             );
-          }
+        final action = await showFirstPostSuccessGuide(
+          context: context,
+          post: latestPost,
+        );
+        await markFirstPostSuccessGuideShown();
+        if (!context.mounted || action == null) {
+          return;
+        }
+        final analytics = ref.read(firebaseAnalyticsServiceProvider);
+        switch (action) {
+          case FirstPostSuccessAction.viewMap:
+            analytics.logEventUnawaited(
+              name: AnalyticsEvent.firstPostSuccessGuideMap,
+            );
+            await controller.onTap(0);
+          case FirstPostSuccessAction.viewAlbum:
+            analytics.logEventUnawaited(
+              name: AnalyticsEvent.firstPostSuccessGuideAlbum,
+            );
+            await controller.onTap(3);
+          case FirstPostSuccessAction.later:
+            analytics.logEventUnawaited(
+              name: AnalyticsEvent.firstPostSuccessGuideLater,
+            );
+        }
       }
     }
 
-    return MediaQuery.removePadding(
-      context: context,
-      removeBottom: Platform.isIOS,
-      child: Scaffold(
-        extendBody: true,
-        // IndexedStack で非選択タブも保持し、往復時の再生成・再購読を防ぐ
-        body: Platform.isIOS
-            ? IndexedStack(
-                index: state.selectedIndex,
-                children: controller.pageList,
-              )
-            : SafeArea(
-                child: IndexedStack(
-                  index: state.selectedIndex,
-                  children: controller.pageList,
+    return Stack(
+      children: [
+        MediaQuery.removePadding(
+          context: context,
+          removeBottom: Platform.isIOS,
+          child: Scaffold(
+            extendBody: true,
+            // IndexedStack で非選択タブも保持し、往復時の再生成・再購読を防ぐ
+            body: Platform.isIOS
+                ? IndexedStack(
+                    index: state.selectedIndex,
+                    children: controller.pageList,
+                  )
+                : SafeArea(
+                    child: IndexedStack(
+                      index: state.selectedIndex,
+                      children: controller.pageList,
+                    ),
+                  ),
+            bottomNavigationBar: Padding(
+              padding: EdgeInsets.fromLTRB(
+                _horizontalMargin,
+                0,
+                _horizontalMargin,
+                _bottomMargin + _bottomSafeInset(context),
+              ),
+              child: SizedBox(
+                height: _barHeight + _postButtonOverlap,
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  alignment: Alignment.bottomCenter,
+                  children: [
+                    Positioned(
+                      left: 0,
+                      right: 0,
+                      bottom: 0,
+                      child: Container(
+                        height: _barHeight,
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.surface,
+                          borderRadius: BorderRadius.circular(_barHeight / 2),
+                          border: Border.all(
+                            color:
+                                Theme.of(context).brightness == Brightness.dark
+                                    ? Colors.white24
+                                    : Colors.grey.shade300,
+                          ),
+                          boxShadow: [
+                            BoxShadow(
+                              color: Colors.black.withValues(alpha: 0.08),
+                              blurRadius: 12,
+                              offset: const Offset(0, 4),
+                            ),
+                          ],
+                        ),
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: _TabItem(
+                                selected: state.selectedIndex == 0,
+                                icon: state.selectedIndex == 0
+                                    ? CupertinoIcons.map_fill
+                                    : CupertinoIcons.map,
+                                label: t.tab.map,
+                                onTap: () => controller.onTap(0),
+                              ),
+                            ),
+                            Expanded(
+                              child: _TabItem(
+                                selected: state.selectedIndex == 1,
+                                icon: state.selectedIndex == 1
+                                    ? Icons.fastfood
+                                    : Icons.fastfood_outlined,
+                                label: t.tab.home,
+                                onTap: () => controller.onTap(1),
+                              ),
+                            ),
+                            const SizedBox(width: _postButtonSize),
+                            Expanded(
+                              child: _TabItem(
+                                selected: state.selectedIndex == 2,
+                                icon: state.selectedIndex == 2
+                                    ? CupertinoIcons.map_pin_ellipse
+                                    : CupertinoIcons.map_pin,
+                                iconSize: 28,
+                                label: t.tab.myMap,
+                                onTap: () => controller.onTap(2),
+                              ),
+                            ),
+                            Expanded(
+                              child: _TabItem(
+                                selected: state.selectedIndex == 3,
+                                icon: state.selectedIndex == 3
+                                    ? CupertinoIcons.person_circle_fill
+                                    : CupertinoIcons.person_circle,
+                                iconSize: 28,
+                                label: t.tab.myPage,
+                                onTap: () => controller.onTap(3),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      bottom: (_barHeight - _postButtonSize) / 2 +
+                          _postButtonOverlap,
+                      child: Semantics(
+                        button: true,
+                        label: t.post.title,
+                        child: Material(
+                          key: postButtonKey,
+                          color: Colors.transparent,
+                          child: InkWell(
+                            onTap: showFirstPostGuide.value
+                                ? null
+                                : onPostPressed,
+                            customBorder: const CircleBorder(),
+                            child: Ink(
+                              width: _postButtonSize,
+                              height: _postButtonSize,
+                              decoration: const BoxDecoration(
+                                color: AppTheme.primaryBlue,
+                                shape: BoxShape.circle,
+                              ),
+                              child: const Icon(
+                                Icons.add,
+                                size: 32,
+                                color: Colors.white,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
-        bottomNavigationBar: Padding(
-          padding: EdgeInsets.fromLTRB(
-            _horizontalMargin,
-            0,
-            _horizontalMargin,
-            _bottomMargin + _bottomSafeInset(context),
-          ),
-          child: SizedBox(
-            height: _barHeight + _postButtonOverlap,
-            child: Stack(
-              clipBehavior: Clip.none,
-              alignment: Alignment.bottomCenter,
-              children: [
-                Positioned(
-                  left: 0,
-                  right: 0,
-                  bottom: 0,
-                  child: Container(
-                    height: _barHeight,
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.surface,
-                      borderRadius: BorderRadius.circular(_barHeight / 2),
-                      border: Border.all(
-                        color: Theme.of(context).brightness == Brightness.dark
-                            ? Colors.white24
-                            : Colors.grey.shade300,
-                      ),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.08),
-                          blurRadius: 12,
-                          offset: const Offset(0, 4),
-                        ),
-                      ],
-                    ),
-                    child: Row(
-                      children: [
-                        Expanded(
-                          child: _TabItem(
-                            selected: state.selectedIndex == 0,
-                            icon: state.selectedIndex == 0
-                                ? CupertinoIcons.map_fill
-                                : CupertinoIcons.map,
-                            label: t.tab.map,
-                            onTap: () => controller.onTap(0),
-                          ),
-                        ),
-                        Expanded(
-                          child: _TabItem(
-                            selected: state.selectedIndex == 1,
-                            icon: state.selectedIndex == 1
-                                ? Icons.fastfood
-                                : Icons.fastfood_outlined,
-                            label: t.tab.home,
-                            onTap: () => controller.onTap(1),
-                          ),
-                        ),
-                        const SizedBox(width: _postButtonSize),
-                        Expanded(
-                          child: _TabItem(
-                            selected: state.selectedIndex == 2,
-                            icon: state.selectedIndex == 2
-                                ? CupertinoIcons.map_pin_ellipse
-                                : CupertinoIcons.map_pin,
-                            iconSize: 28,
-                            label: t.tab.myMap,
-                            onTap: () => controller.onTap(2),
-                          ),
-                        ),
-                        Expanded(
-                          child: _TabItem(
-                            selected: state.selectedIndex == 3,
-                            icon: state.selectedIndex == 3
-                                ? CupertinoIcons.person_circle_fill
-                                : CupertinoIcons.person_circle,
-                            iconSize: 28,
-                            label: t.tab.myPage,
-                            onTap: () => controller.onTap(3),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-                Positioned(
-                  bottom:
-                      (_barHeight - _postButtonSize) / 2 + _postButtonOverlap,
-                  child: Semantics(
-                    button: true,
-                    label: t.post.title,
-                    child: Material(
-                      color: Colors.transparent,
-                      child: InkWell(
-                        onTap: onPostPressed,
-                        customBorder: const CircleBorder(),
-                        child: Ink(
-                          width: _postButtonSize,
-                          height: _postButtonSize,
-                          decoration: const BoxDecoration(
-                            color: AppTheme.primaryBlue,
-                            shape: BoxShape.circle,
-                          ),
-                          child: const Icon(
-                            Icons.add,
-                            size: 32,
-                            color: Colors.white,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              ],
             ),
           ),
         ),
-      ),
+        if (showFirstPostGuide.value)
+          FirstPostGuideOverlay(
+            buttonKey: postButtonKey,
+            onTapPost: () async {
+              await dismissFirstPostGuide(tappedPost: true);
+              if (context.mounted) {
+                await onPostPressed();
+              }
+            },
+            onDismiss: () async {
+              await dismissFirstPostGuide(tappedPost: false);
+            },
+          ),
+      ],
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1369,10 +1369,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -2062,10 +2062,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue

- close #1183
- close #1184 


## 概要

- 初めて開いた時に投稿のガイドを出現するようにしました

## 追加したPackage

- なし

## Screenshot

| TH | TH | TH |
| ---- | ---- | ---- |
| <img width="585" height="1266" alt="IMG_5396" src="https://github.com/user-attachments/assets/2fa094ce-5400-44d2-bd24-cfc4f473bbe2" /> | <img width="585" height="1266" alt="IMG_5398" src="https://github.com/user-attachments/assets/2ffb173a-9c3e-4db1-ab01-edfa19b14160" /> | <img width="585" height="1266" alt="IMG_5399" src="https://github.com/user-attachments/assets/62eba2bd-dc88-42d7-8533-f79df2c7b716" /> |




## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a first-post onboarding guide that highlights the post button and provides localized prompts.
  * Added a post-success guide with post details and options to view the map, open the album, or continue later.
  * Added support for German, English, Spanish, French, Japanese, Korean, Portuguese, Thai, Vietnamese, Simplified Chinese, and Traditional Chinese.
  * Added event tracking for guide displays, interactions, dismissals, and follow-up choices.
* **Style**
  * Removed visible borders from name and self-introduction fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->