### PR TITLE
タイムラインや投稿詳細画面など自動翻訳をして、表示を国ごとに適応できるようにしました

### DIFF
--- a/lib/core/translation/translation_service.dart
+++ b/lib/core/translation/translation_service.dart
@@ -48,7 +48,7 @@ class TranslationService {
     // 言語を推定
     final detected = await _safeIdentifyLanguage(trimmed);
     final targetBcp47 = _localeToBcp47(targetLocale);
-    if (detected == null || detected == targetBcp47) {
+    if (detected == null || _isSameLanguage(detected, targetBcp47)) {
       return text;
     }
 
@@ -103,7 +103,12 @@ class TranslationService {
       return false;
     }
     final targetBcp47 = _localeToBcp47(targetLocale);
-    return detected != targetBcp47;
+    return !_isSameLanguage(detected, targetBcp47);
+  }
+
+  /// 言語コードのみを比較する（例: ja と ja-JP は同一言語）。
+  bool _isSameLanguage(String a, String b) {
+    return a.split('-').first.toLowerCase() == b.split('-').first.toLowerCase();
   }
 
   /// 文字列の言語を推定し、BCP-47 形式（正規化後）で返す。

--- a/lib/ui/component/app_translatable_text.dart
+++ b/lib/ui/component/app_translatable_text.dart
@@ -13,14 +13,22 @@ class AppTranslatableText extends ConsumerStatefulWidget {
     this.style,
     this.overflow,
     this.textAlign,
+    this.maxLines,
+    this.softWrap,
     this.enableCopy = true,
+    this.autoTranslate = false,
   });
 
   final String text;
   final TextStyle? style;
   final TextOverflow? overflow;
   final TextAlign? textAlign;
+  final int? maxLines;
+  final bool? softWrap;
   final bool enableCopy;
+
+  /// true のとき、アプリ言語へ自動翻訳して表示する。
+  final bool autoTranslate;
 
   @override
   ConsumerState<AppTranslatableText> createState() => _TranslatableTextState();
@@ -30,10 +38,52 @@ class _TranslatableTextState extends ConsumerState<AppTranslatableText> {
   String? _translated;
   // 二重実行防止のためのフラグ
   bool _isTranslating = false;
+  // ユーザーが原文表示を選んだ場合は自動翻訳結果を出さない
+  bool _showOriginal = false;
+  Locale? _lastLocale;
+  String? _lastSourceText;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final locale = Localizations.localeOf(context);
+    if (widget.autoTranslate &&
+        (_lastLocale != locale || _lastSourceText != widget.text)) {
+      _lastLocale = locale;
+      _lastSourceText = widget.text;
+      _showOriginal = false;
+      _translated = null;
+      _scheduleAutoTranslate();
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant AppTranslatableText oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.text != widget.text ||
+        oldWidget.autoTranslate != widget.autoTranslate) {
+      _showOriginal = false;
+      _translated = null;
+      _lastSourceText = widget.text;
+      if (widget.autoTranslate) {
+        _scheduleAutoTranslate();
+      }
+    }
+  }
+
+  void _scheduleAutoTranslate() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      _handleTranslate(silent: true);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
-    final displayText = _translated ?? widget.text;
+    final displayText =
+        (!_showOriginal && _translated != null) ? _translated! : widget.text;
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onLongPress: _onLongPress,
@@ -42,6 +92,8 @@ class _TranslatableTextState extends ConsumerState<AppTranslatableText> {
         style: widget.style,
         overflow: widget.overflow,
         textAlign: widget.textAlign,
+        maxLines: widget.maxLines,
+        softWrap: widget.softWrap,
       ),
     );
   }
@@ -54,6 +106,7 @@ class _TranslatableTextState extends ConsumerState<AppTranslatableText> {
     final translateLabel = t.translatable.translate;
     final showOriginalLabel = t.translatable.showOriginal;
     final copyLabel = t.translatable.copy;
+    final showingTranslated = !_showOriginal && _translated != null;
     // 長押しメニュー（翻訳/原文/コピー）
     final action = await showModalBottomSheet<String>(
       context: context,
@@ -62,12 +115,13 @@ class _TranslatableTextState extends ConsumerState<AppTranslatableText> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              ListTile(
-                leading: const Icon(Icons.translate),
-                title: Text(translateLabel),
-                onTap: () => Navigator.of(ctx).pop('translate'),
-              ),
-              if (_translated != null)
+              if (!showingTranslated)
+                ListTile(
+                  leading: const Icon(Icons.translate),
+                  title: Text(translateLabel),
+                  onTap: () => Navigator.of(ctx).pop('translate'),
+                ),
+              if (showingTranslated)
                 ListTile(
                   leading: const Icon(Icons.undo),
                   title: Text(showOriginalLabel),
@@ -90,28 +144,29 @@ class _TranslatableTextState extends ConsumerState<AppTranslatableText> {
     }
     switch (action) {
       case 'translate':
-        await _handleTranslate();
+        _showOriginal = false;
+        await _handleTranslate(silent: false);
       case 'original':
-        setState(() => _translated = null);
+        setState(() => _showOriginal = true);
       case 'copy':
         await _handleCopy();
     }
   }
 
-  Future<void> _handleTranslate() async {
+  Future<void> _handleTranslate({required bool silent}) async {
     // 多重翻訳の連打対策
     if (_isTranslating) {
       return;
     }
     final svc = ref.read(translationServiceProvider);
     final locale = Localizations.localeOf(context);
-    // 同一言語であれば何もしない（SnackBarも出さない）
+    // 同一言語であれば何もしない
     final need = await svc.shouldTranslate(
       text: widget.text,
       targetLocale: locale,
     );
     if (!need) {
-      if (!mounted) {
+      if (!mounted || silent) {
         return;
       }
       final t = Translations.of(context);
@@ -129,18 +184,25 @@ class _TranslatableTextState extends ConsumerState<AppTranslatableText> {
       if (!mounted) {
         return;
       }
-      // 翻訳できなかった（原文と同じ）の場合はSnackBarを表示
+      // 翻訳できなかった（原文と同じ）の場合
       if (out.trim() == widget.text.trim()) {
-        final t = Translations.of(context);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(t.translatable.translateFailed)),
-        );
+        if (!silent) {
+          final t = Translations.of(context);
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(t.translatable.translateFailed)),
+          );
+        }
         return;
       }
-      setState(() => _translated = out);
-      await ref.read(firebaseAnalyticsServiceProvider).logEvent(
-            name: AnalyticsEvent.postTranslate,
-          );
+      setState(() {
+        _translated = out;
+        _showOriginal = false;
+      });
+      if (!silent) {
+        await ref.read(firebaseAnalyticsServiceProvider).logEvent(
+              name: AnalyticsEvent.postTranslate,
+            );
+      }
     } finally {
       if (mounted) {
         setState(() => _isTranslating = false);
@@ -149,7 +211,8 @@ class _TranslatableTextState extends ConsumerState<AppTranslatableText> {
   }
 
   Future<void> _handleCopy() async {
-    final text = _translated ?? widget.text;
+    final text =
+        (!_showOriginal && _translated != null) ? _translated! : widget.text;
     await Clipboard.setData(ClipboardData(text: text));
     if (!mounted) {
       return;

--- a/lib/ui/component/app_translatable_text.dart
+++ b/lib/ui/component/app_translatable_text.dart
@@ -36,12 +36,15 @@ class AppTranslatableText extends ConsumerStatefulWidget {
 
 class _TranslatableTextState extends ConsumerState<AppTranslatableText> {
   String? _translated;
-  // 二重実行防止のためのフラグ
   bool _isTranslating = false;
   // ユーザーが原文表示を選んだ場合は自動翻訳結果を出さない
   bool _showOriginal = false;
   Locale? _lastLocale;
   String? _lastSourceText;
+  // テキスト / ロケール変更のたびに増え、古い翻訳結果を捨てる
+  int _generation = 0;
+  // 翻訳中に新しい自動翻訳要求が来た場合に再実行する
+  bool _pendingAutoTranslate = false;
 
   @override
   void didChangeDependencies() {
@@ -49,10 +52,7 @@ class _TranslatableTextState extends ConsumerState<AppTranslatableText> {
     final locale = Localizations.localeOf(context);
     if (widget.autoTranslate &&
         (_lastLocale != locale || _lastSourceText != widget.text)) {
-      _lastLocale = locale;
-      _lastSourceText = widget.text;
-      _showOriginal = false;
-      _translated = null;
+      _invalidateTranslation(locale: locale, sourceText: widget.text);
       _scheduleAutoTranslate();
     }
   }
@@ -62,18 +62,34 @@ class _TranslatableTextState extends ConsumerState<AppTranslatableText> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.text != widget.text ||
         oldWidget.autoTranslate != widget.autoTranslate) {
-      _showOriginal = false;
-      _translated = null;
-      _lastSourceText = widget.text;
+      _invalidateTranslation(
+        locale: _lastLocale ?? Localizations.localeOf(context),
+        sourceText: widget.text,
+      );
       if (widget.autoTranslate) {
         _scheduleAutoTranslate();
       }
     }
   }
 
+  void _invalidateTranslation({
+    required Locale locale,
+    required String sourceText,
+  }) {
+    _generation++;
+    _showOriginal = false;
+    _translated = null;
+    _lastLocale = locale;
+    _lastSourceText = sourceText;
+  }
+
   void _scheduleAutoTranslate() {
+    if (_isTranslating) {
+      _pendingAutoTranslate = true;
+      return;
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) {
+      if (!mounted || !widget.autoTranslate) {
         return;
       }
       _handleTranslate(silent: true);
@@ -154,17 +170,29 @@ class _TranslatableTextState extends ConsumerState<AppTranslatableText> {
   }
 
   Future<void> _handleTranslate({required bool silent}) async {
-    // 多重翻訳の連打対策
     if (_isTranslating) {
+      if (silent) {
+        _pendingAutoTranslate = true;
+      }
       return;
     }
+
     final svc = ref.read(translationServiceProvider);
+    final sourceText = widget.text;
     final locale = Localizations.localeOf(context);
-    // 同一言語であれば何もしない
+    final requestGeneration = _generation;
+
     final need = await svc.shouldTranslate(
-      text: widget.text,
+      text: sourceText,
       targetLocale: locale,
     );
+    if (!_isCurrentRequest(
+      generation: requestGeneration,
+      sourceText: sourceText,
+      locale: locale,
+    )) {
+      return;
+    }
     if (!need) {
       if (!mounted || silent) {
         return;
@@ -175,17 +203,22 @@ class _TranslatableTextState extends ConsumerState<AppTranslatableText> {
       );
       return;
     }
+
     setState(() => _isTranslating = true);
     try {
       final out = await svc.translateIfNeeded(
-        text: widget.text,
+        text: sourceText,
         targetLocale: locale,
       );
-      if (!mounted) {
+      if (!_isCurrentRequest(
+        generation: requestGeneration,
+        sourceText: sourceText,
+        locale: locale,
+      )) {
         return;
       }
       // 翻訳できなかった（原文と同じ）の場合
-      if (out.trim() == widget.text.trim()) {
+      if (out.trim() == sourceText.trim()) {
         if (!silent) {
           final t = Translations.of(context);
           ScaffoldMessenger.of(context).showSnackBar(
@@ -206,8 +239,27 @@ class _TranslatableTextState extends ConsumerState<AppTranslatableText> {
     } finally {
       if (mounted) {
         setState(() => _isTranslating = false);
+      } else {
+        _isTranslating = false;
+      }
+      if (_pendingAutoTranslate && mounted && widget.autoTranslate) {
+        _pendingAutoTranslate = false;
+        _scheduleAutoTranslate();
       }
     }
+  }
+
+  bool _isCurrentRequest({
+    required int generation,
+    required String sourceText,
+    required Locale locale,
+  }) {
+    if (!mounted) {
+      return false;
+    }
+    return generation == _generation &&
+        sourceText == widget.text &&
+        locale == Localizations.localeOf(context);
   }
 
   Future<void> _handleCopy() async {

--- a/lib/ui/component/common/app_card_list_item.dart
+++ b/lib/ui/component/common/app_card_list_item.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:food_gram_app/core/model/posts.dart';
 import 'package:food_gram_app/core/supabase/current_user_provider.dart';
 import 'package:food_gram_app/gen/assets.gen.dart';
+import 'package:food_gram_app/ui/component/app_translatable_text.dart';
 
 class AppCardListItem extends ConsumerWidget {
   const AppCardListItem({
@@ -97,7 +98,7 @@ class AppCardListItem extends ConsumerWidget {
                 color: Colors.black.withValues(alpha: 0.7),
                 borderRadius: BorderRadius.circular(20),
               ),
-              child: Text(
+              child: AppTranslatableText(
                 restaurantName,
                 style: const TextStyle(
                   color: Colors.white,
@@ -107,6 +108,8 @@ class AppCardListItem extends ConsumerWidget {
                 overflow: TextOverflow.ellipsis,
                 maxLines: 2,
                 softWrap: false,
+                enableCopy: false,
+                autoTranslate: true,
               ),
             ),
           ),

--- a/lib/ui/component/common/app_list_view.dart
+++ b/lib/ui/component/common/app_list_view.dart
@@ -13,6 +13,7 @@ import 'package:food_gram_app/core/supabase/post/repository/detail_post_reposito
 import 'package:food_gram_app/core/supabase/user/providers/subscribed_users_provider.dart';
 import 'package:food_gram_app/gen/assets.gen.dart';
 import 'package:food_gram_app/router/router.dart';
+import 'package:food_gram_app/ui/component/app_translatable_text.dart';
 import 'package:food_gram_app/ui/component/common/app_empty.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -196,11 +197,13 @@ class AppListView extends HookConsumerWidget {
                                   horizontal: 8,
                                   vertical: 3,
                                 ),
-                                child: Text(
+                                child: AppTranslatableText(
                                   post.restaurant,
                                   maxLines: 1,
                                   overflow: TextOverflow.ellipsis,
                                   textAlign: TextAlign.center,
+                                  enableCopy: false,
+                                  autoTranslate: true,
                                   style: const TextStyle(
                                     color: Colors.white,
                                     fontSize: 9,

--- a/lib/ui/screen/post_detail/component/post_detail_list_item.dart
+++ b/lib/ui/screen/post_detail/component/post_detail_list_item.dart
@@ -503,6 +503,7 @@ class PostDetailListItem extends HookConsumerWidget {
                     AppTranslatableText(
                       posts.foodName,
                       style: DetailPostStyle.foodName(context),
+                      autoTranslate: true,
                     ),
                     const Gap(4),
                     Row(
@@ -515,10 +516,22 @@ class PostDetailListItem extends HookConsumerWidget {
                                 extra: posts,
                               );
                             },
-                            child: Text(
-                              'In ${posts.restaurant}',
-                              style: DetailPostStyle.restaurant(context),
-                              overflow: TextOverflow.ellipsis,
+                            child: Row(
+                              children: [
+                                Text(
+                                  'In ',
+                                  style: DetailPostStyle.restaurant(context),
+                                ),
+                                Expanded(
+                                  child: AppTranslatableText(
+                                    posts.restaurant,
+                                    style: DetailPostStyle.restaurant(context),
+                                    overflow: TextOverflow.ellipsis,
+                                    maxLines: 1,
+                                    autoTranslate: true,
+                                  ),
+                                ),
+                              ],
                             ),
                           ),
                         ),
@@ -568,6 +581,7 @@ class PostDetailListItem extends HookConsumerWidget {
                       AppTranslatableText(
                         posts.comment,
                         style: DetailPostStyle.comment(context),
+                        autoTranslate: true,
                       ),
                     const Gap(4),
                     Text(

--- a/lib/ui/screen/restaurant_review/restaurant_review_screen.dart
+++ b/lib/ui/screen/restaurant_review/restaurant_review_screen.dart
@@ -11,6 +11,7 @@ import 'package:food_gram_app/core/theme/style/restaurant_review_style.dart';
 import 'package:food_gram_app/gen/strings.g.dart';
 import 'package:food_gram_app/router/router.dart';
 import 'package:food_gram_app/ui/component/app_profile_image.dart';
+import 'package:food_gram_app/ui/component/app_translatable_text.dart';
 import 'package:food_gram_app/ui/component/common/app_async_value_group.dart';
 import 'package:gap/gap.dart';
 import 'package:go_router/go_router.dart';
@@ -70,9 +71,10 @@ class RestaurantReviewScreen extends HookConsumerWidget {
           child: const Icon(Icons.close, size: 30),
         ),
         title: FittedBox(
-          child: Text(
+          child: AppTranslatableText(
             posts.restaurant,
             style: RestaurantReviewStyle.restaurant(colorScheme.onSurface),
+            autoTranslate: true,
           ),
         ),
       ),

--- a/lib/ui/screen/time_line/components/timeline_feed_section.dart
+++ b/lib/ui/screen/time_line/components/timeline_feed_section.dart
@@ -9,6 +9,7 @@ import 'package:food_gram_app/core/supabase/current_user_provider.dart';
 import 'package:food_gram_app/core/supabase/user/providers/subscribed_users_provider.dart';
 import 'package:food_gram_app/gen/assets.gen.dart';
 import 'package:food_gram_app/gen/strings.g.dart';
+import 'package:food_gram_app/ui/component/app_translatable_text.dart';
 import 'package:food_gram_app/ui/component/common/app_empty.dart';
 import 'package:food_gram_app/ui/screen/time_line/components/timeline_post_navigation.dart';
 import 'package:gap/gap.dart';
@@ -185,10 +186,12 @@ class _TimelineFeedCard extends ConsumerWidget {
           ),
           const Gap(4),
           Expanded(
-            child: Text(
+            child: AppTranslatableText(
               post.restaurant.isNotEmpty ? post.restaurant : post.foodName,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
+              enableCopy: false,
+              autoTranslate: true,
               style: TextStyle(
                 fontSize: 12,
                 fontWeight: FontWeight.w600,

--- a/lib/ui/screen/time_line/components/timeline_recommend_section.dart
+++ b/lib/ui/screen/time_line/components/timeline_recommend_section.dart
@@ -13,6 +13,7 @@ import 'package:food_gram_app/core/utils/helpers/snack_bar_helper.dart';
 import 'package:food_gram_app/core/utils/location/prefecture_detector.dart';
 import 'package:food_gram_app/gen/assets.gen.dart';
 import 'package:food_gram_app/gen/strings.g.dart';
+import 'package:food_gram_app/ui/component/app_translatable_text.dart';
 import 'package:food_gram_app/ui/component/modal_sheet/save_album_picker_sheet.dart';
 import 'package:food_gram_app/ui/screen/post_detail/post_detail_view_model.dart';
 import 'package:food_gram_app/ui/screen/time_line/components/timeline_post_navigation.dart';
@@ -488,10 +489,12 @@ class _TimelineFeaturedCard extends HookConsumerWidget {
                           ),
                           if (isExpanded && post.restaurant.isNotEmpty) ...[
                             const Gap(4),
-                            Text(
+                            AppTranslatableText(
                               post.restaurant,
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
+                              enableCopy: false,
+                              autoTranslate: true,
                               style: TextStyle(
                                 color: Colors.white.withValues(alpha: 0.92),
                                 fontSize: 13,


### PR DESCRIPTION
## Issue

- close #1203 

## 概要

- タイムラインや投稿詳細画面など自動翻訳をして、表示を国ごとに適応できるようにしました

## 追加したPackage

- なし

## Screenshot

| TH | TH |
| ---- | ---- |
| <img width="585" height="1266" alt="IMG_5565" src="https://github.com/user-attachments/assets/1f39ece5-882a-4919-87fd-ea0f49fafb1b" /> | <img width="585" height="1266" alt="IMG_5566" src="https://github.com/user-attachments/assets/ff705dea-ec26-40b6-b0f5-e2d1817798ab" /> |

| TH | TH |
| ---- | ---- |
| <img width="585" height="1266" alt="IMG_5567" src="https://github.com/user-attachments/assets/b437e2df-235d-4330-969b-6ced9cc6fbda" /> | <img width="585" height="1266" alt="IMG_5568" src="https://github.com/user-attachments/assets/a7296afb-36ba-40a8-8c8d-c7f5169861ef" /> |





## 備考

