### PR TITLE
タブ画面において、タップをすると、ページを横に遷移するみたいなアニメーションをつけました

### DIFF
--- a/lib/ui/component/common/keep_alive_page_view.dart
+++ b/lib/ui/component/common/keep_alive_page_view.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+/// 各ページの状態を保持するPageViewのラッパー
+class KeepAlivePageView extends StatelessWidget {
+  const KeepAlivePageView({
+    super.key,
+    required this.controller,
+    required this.children,
+    this.physics,
+    this.onPageChanged,
+  });
+
+  final PageController controller;
+  final List<Widget> children;
+  final ScrollPhysics? physics;
+  final ValueChanged<int>? onPageChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return PageView(
+      controller: controller,
+      physics: physics,
+      onPageChanged: onPageChanged,
+      children: children.map((child) => _KeepAlivePage(child: child)).toList(),
+    );
+  }
+}
+
+/// 各ページを状態保持するラッパークラス
+class _KeepAlivePage extends StatefulWidget {
+  const _KeepAlivePage({required this.child});
+  
+  final Widget child;
+
+  @override
+  State<_KeepAlivePage> createState() => _KeepAlivePageState();
+}
+
+class _KeepAlivePageState extends State<_KeepAlivePage>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context); // AutomaticKeepAliveClientMixinに必要
+    return widget.child;
+  }
+}

--- a/lib/ui/screen/tab/tab_screen.dart
+++ b/lib/ui/screen/tab/tab_screen.dart
@@ -77,15 +77,19 @@ class TabScreen extends HookConsumerWidget {
     final pageController =
         useMemoized(() => PageController(initialPage: state.selectedIndex));
 
-    // PageControllerをViewModelに設定
+    // PageControllerをViewModelに設定し、適切にクリーンアップ
     useEffect(
       () {
         controller.setPageController(pageController);
-        return () {};
+        return () {
+          // TabScreenがアンマウントされる時にPageControllerの参照をクリア
+          controller.clearPageController(pageController);
+        };
       },
-      [pageController],
+      [], // pageControllerをキーに含めない（memoizedなので）
     );
-
+    // PageControllerの破棄処理
+    useEffect(() => pageController.dispose, []);
     useEffect(
       () {
         var cancelled = false;

--- a/lib/ui/screen/tab/tab_screen.dart
+++ b/lib/ui/screen/tab/tab_screen.dart
@@ -19,6 +19,7 @@ import 'package:food_gram_app/core/theme/style/tab_style.dart';
 import 'package:food_gram_app/core/utils/user_level.dart';
 import 'package:food_gram_app/gen/strings.g.dart';
 import 'package:food_gram_app/router/router.dart';
+import 'package:food_gram_app/ui/component/common/keep_alive_page_view.dart';
 import 'package:food_gram_app/ui/component/dialog/app_level_up_dialog.dart';
 import 'package:food_gram_app/ui/component/guide/first_post_guide_overlay.dart';
 import 'package:food_gram_app/ui/component/guide/first_post_success_dialog.dart';
@@ -73,6 +74,17 @@ class TabScreen extends HookConsumerWidget {
     final t = Translations.of(context);
     final postButtonKey = useMemoized(GlobalKey.new);
     final showFirstPostGuide = useState(false);
+    final pageController =
+        useMemoized(() => PageController(initialPage: state.selectedIndex));
+
+    // PageControllerをViewModelに設定
+    useEffect(
+      () {
+        controller.setPageController(pageController);
+        return () {};
+      },
+      [pageController],
+    );
 
     useEffect(
       () {
@@ -266,15 +278,17 @@ class TabScreen extends HookConsumerWidget {
           removeBottom: Platform.isIOS,
           child: Scaffold(
             extendBody: true,
-            // IndexedStack で非選択タブも保持し、往復時の再生成・再購読を防ぐ
+            // KeepAlivePageView でスムーズなアニメーション + 状態保持を実装
             body: Platform.isIOS
-                ? IndexedStack(
-                    index: state.selectedIndex,
+                ? KeepAlivePageView(
+                    controller: pageController,
+                    physics: const NeverScrollableScrollPhysics(), // スワイプ無効
                     children: controller.pageList,
                   )
                 : SafeArea(
-                    child: IndexedStack(
-                      index: state.selectedIndex,
+                    child: KeepAlivePageView(
+                      controller: pageController,
+                      physics: const NeverScrollableScrollPhysics(), // スワイプ無効
                       children: controller.pageList,
                     ),
                   ),
@@ -373,9 +387,8 @@ class TabScreen extends HookConsumerWidget {
                           key: postButtonKey,
                           color: Colors.transparent,
                           child: InkWell(
-                            onTap: showFirstPostGuide.value
-                                ? null
-                                : onPostPressed,
+                            onTap:
+                                showFirstPostGuide.value ? null : onPostPressed,
                             customBorder: const CircleBorder(),
                             child: Ink(
                               width: _postButtonSize,

--- a/lib/ui/screen/tab/tab_view_model.dart
+++ b/lib/ui/screen/tab/tab_view_model.dart
@@ -43,6 +43,13 @@ class TabViewModel extends _$TabViewModel {
     _pageController = controller;
   }
 
+  void clearPageController(PageController controller) {
+    // 同じコントローラーの場合のみクリア
+    if (_pageController == controller) {
+      _pageController = null;
+    }
+  }
+
   void _logInitialTabIfNeeded() {
     if (_didLogInitialTab) {
       return;
@@ -97,12 +104,16 @@ class TabViewModel extends _$TabViewModel {
     }
     
     // PageControllerを使ってスムーズにページを切り替え
-    if (_pageController != null) {
-      _pageController!.animateToPage(
-        index,
-        duration: const Duration(milliseconds: 400),
-        curve: Curves.easeInOutCubic,
-      );
+    if (_pageController != null && _pageController!.hasClients) {
+      try {
+        _pageController!.animateToPage(
+          index,
+          duration: const Duration(milliseconds: 400),
+          curve: Curves.easeInOutCubic,
+        );
+      } catch (e) {
+        // PageControllerが破棄済みの場合は無視
+      }
     }
     
     state = TabState(selectedIndex: index);

--- a/lib/ui/screen/tab/tab_view_model.dart
+++ b/lib/ui/screen/tab/tab_view_model.dart
@@ -20,6 +20,7 @@ final scrollToTopForTabProvider =
 class TabViewModel extends _$TabViewModel {
   bool _isHandlingTap = false;
   bool _didLogInitialTab = false;
+  PageController? _pageController;
 
   @override
   TabState build({
@@ -37,6 +38,10 @@ class TabViewModel extends _$TabViewModel {
     const RecordScreen(),
     const MyProfileScreen(),
   ];
+
+  void setPageController(PageController controller) {
+    _pageController = controller;
+  }
 
   void _logInitialTabIfNeeded() {
     if (_didLogInitialTab) {
@@ -90,6 +95,16 @@ class TabViewModel extends _$TabViewModel {
         trigger: (current?.trigger ?? -1) + 1,
       );
     }
+    
+    // PageControllerを使ってスムーズにページを切り替え
+    if (_pageController != null) {
+      _pageController!.animateToPage(
+        index,
+        duration: const Duration(milliseconds: 400),
+        curve: Curves.easeInOutCubic,
+      );
+    }
+    
     state = TabState(selectedIndex: index);
   }
 


### PR DESCRIPTION
## Issue

- close #1209

## 概要

- タブ画面において、タップをすると、ページを横に遷移するみたいなアニメーションをつけました

## 追加したPackage

- なし

## Screenshot

|理想|実装|
|:-:|:-:|
|<video src="https://github.com/user-attachments/assets/53bc93a6-a88f-4d37-8e44-9a0bf2ac65a0">|<video src="https://github.com/user-attachments/assets/a3e1dcce-498c-4bb2-a267-cadc75c920f5">|









## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added smooth animated transitions when switching between tabs.
  - Preserved each tab’s state while navigating between pages.
  - Maintained support for swipe-disabled navigation and platform-specific layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->