### PR TITLE
投稿詳細を閉じる時に広告のロード待ちで固まらないようにしました

### DIFF
--- a/lib/core/admob/services/admob_interstitial.dart
+++ b/lib/core/admob/services/admob_interstitial.dart
@@ -33,32 +33,58 @@ class AdmobInterstitial {
   bool _isAdShowing = false;
   DateTime? _lastAdShowTime;
   int _postDetailCloseCount = 0;
+  bool _hasPendingPostDetailAd = false;
 
   bool get isAdReady => _isAdReady;
 
-  /// 投稿詳細を閉じた回数を記録し、表示タイミングかどうかを返す
+  /// 投稿詳細を閉じた回数を記録し、いま広告を表示すべきかを返す。
+  ///
+  /// 表示タイミングに当たっても未準備・クールダウン中なら false を返し、
+  /// 表示権は次に閉じたときへ持ち越す。閉じる操作をロード待ちで
+  /// ブロックしないための仕組み。
   bool registerPostDetailCloseAndShouldShow() {
     _postDetailCloseCount++;
-    final shouldShow = _postDetailCloseCount % postDetailCloseAdInterval == 0;
+    if (_postDetailCloseCount % postDetailCloseAdInterval == 0) {
+      _hasPendingPostDetailAd = true;
+    }
     logger.d(
       'Post detail close count: $_postDetailCloseCount / '
-      'interval: $postDetailCloseAdInterval, shouldShow: $shouldShow',
+      'interval: $postDetailCloseAdInterval, '
+      'pending: $_hasPendingPostDetailAd',
     );
-    return shouldShow;
+    if (!_hasPendingPostDetailAd) {
+      return false;
+    }
+    if (!_canShowAd()) {
+      logger.i('Post detail ad deferred to the next close');
+      createAd();
+      return false;
+    }
+    return true;
   }
 
   /// 広告を作成して読み込む
   void createAd({bool resetAttempts = false}) {
-    if (_isAdsBlocked() || _isDisposed) {
+    final isBlocked = _isAdsBlocked();
+    if (isBlocked || _isDisposed) {
+      logger.d(
+        'Interstitial load skipped: blocked=$isBlocked, '
+        'disposed=$_isDisposed',
+      );
       return;
     }
     if (resetAttempts) {
       _loadAttempts = 0;
     }
     if (_isAdReady || _isAdLoading || _loadAttempts >= maxLoadAttempts) {
+      logger.d(
+        'Interstitial load skipped: ready=$_isAdReady, '
+        'loading=$_isAdLoading, attempts=$_loadAttempts',
+      );
       return;
     }
 
+    logger.d('Interstitial load requested');
     final loadGeneration = ++_loadGeneration;
     _isAdLoading = true;
     InterstitialAd.load(
@@ -189,6 +215,7 @@ class AdmobInterstitial {
       onAdShowedFullScreenContent: (ad) {
         _isAdShowing = true;
         _lastAdShowTime = DateTime.now();
+        _hasPendingPostDetailAd = false;
         logger.i('Ad displayed');
         onAdShown?.call();
       },
@@ -244,28 +271,33 @@ class AdmobInterstitial {
     _isAdReady = false;
     _isAdLoading = false;
     _isAdShowing = false;
+    _hasPendingPostDetailAd = false;
   }
 }
 
 /// インタースティシャル広告の状態を管理するプロバイダー
 @Riverpod(keepAlive: true)
 class AdmobInterstitialNotifier extends _$AdmobInterstitialNotifier {
-  AdmobInterstitial? _admobInterstitial;
-
   @override
   AdmobInterstitial build() {
-    final allowAds = canRequestAds(ref.watch(isSubscribeProvider));
-
-    ref.onDispose(() => _admobInterstitial?.dispose());
-
-    _admobInterstitial ??= AdmobInterstitial(
+    final interstitial = AdmobInterstitial(
       isAdsBlocked: () => !canRequestAdsFrom(ref),
     );
-    if (allowAds) {
-      _admobInterstitial!.createAd();
-    } else {
-      _admobInterstitial!.discardLoadedAd();
-    }
-    return _admobInterstitial!;
+    // watch にすると購読状態が変わるたび build が再実行され、
+    // 前回ビルド分の onDispose が走って広告インスタンスが無効化される。
+    // listen なら build は一度だけで、onDispose も本当の破棄時にしか走らない。
+    ref.listen(
+      isSubscribeProvider,
+      (_, next) {
+        if (canRequestAds(next)) {
+          interstitial.createAd(resetAttempts: true);
+        } else {
+          interstitial.discardLoadedAd();
+        }
+      },
+      fireImmediately: true,
+    );
+    ref.onDispose(interstitial.dispose);
+    return interstitial;
   }
 }

--- a/lib/core/admob/services/admob_interstitial.dart
+++ b/lib/core/admob/services/admob_interstitial.dart
@@ -255,12 +255,17 @@ class AdmobInterstitial {
     }
   }
 
+  /// 読み込み済みの広告と持ち越し中の表示権を破棄する。
+  ///
+  /// 表示権を残すと、再び広告対象に戻った直後の1回目で
+  /// 設定した間隔を待たずに表示されてしまう。
   void discardLoadedAd() {
     _loadGeneration++;
     _interstitialAd?.dispose();
     _interstitialAd = null;
     _isAdReady = false;
     _isAdLoading = false;
+    _hasPendingPostDetailAd = false;
   }
 
   void dispose() {

--- a/lib/core/admob/services/admob_open.dart
+++ b/lib/core/admob/services/admob_open.dart
@@ -244,22 +244,26 @@ class AdmobOpen {
 /// アプリオープン広告の状態を管理するプロバイダー
 @Riverpod(keepAlive: true)
 class AdmobOpenNotifier extends _$AdmobOpenNotifier {
-  AdmobOpen? _admobOpen;
-
   @override
   AdmobOpen build() {
-    final allowAds = canRequestAds(ref.watch(isSubscribeProvider));
-
-    ref.onDispose(() => _admobOpen?.dispose());
-
-    _admobOpen ??= AdmobOpen(
+    final admobOpen = AdmobOpen(
       isAdsBlocked: () => !canRequestAdsFrom(ref),
     );
-    if (allowAds) {
-      _admobOpen!.loadAd();
-    } else {
-      _admobOpen!.discardLoadedAd();
-    }
-    return _admobOpen!;
+    // watch にすると購読状態が変わるたび build が再実行され、
+    // 前回ビルド分の onDispose で読み込み済み広告とタブ切り替え回数が
+    // リセットされてしまう。
+    ref.listen(
+      isSubscribeProvider,
+      (_, next) {
+        if (canRequestAds(next)) {
+          admobOpen.loadAd(resetAttempts: true);
+        } else {
+          admobOpen.discardLoadedAd();
+        }
+      },
+      fireImmediately: true,
+    );
+    ref.onDispose(admobOpen.dispose);
+    return admobOpen;
   }
 }

--- a/lib/ui/screen/post_detail/post_detail_screen.dart
+++ b/lib/ui/screen/post_detail/post_detail_screen.dart
@@ -52,6 +52,12 @@ class PostDetailScreen extends HookConsumerWidget {
         ref
             .read(postDetailViewModelProvider().notifier)
             .initializeHeartState(posts.id, posts.heart);
+        // 閉じる瞬間に待たせないため、滞在時間を使って先読みしておく
+        if (canRequestAds(ref.read(isSubscribeProvider))) {
+          ref
+              .read(admobInterstitialNotifierProvider)
+              .createAd(resetAttempts: true);
+        }
         return;
       },
       [posts.id],
@@ -87,27 +93,18 @@ class PostDetailScreen extends HookConsumerWidget {
     final adInterstitial = ref.watch(admobInterstitialNotifierProvider);
     final isClosing = useState(false);
 
-    Future<void> closeDetail() async {
+    void closeDetail() {
       if (isClosing.value || loading || menuLoading.value || isInitialLoading) {
         return;
       }
       isClosing.value = true;
-      try {
-        void popDetail() {
-          if (context.mounted) {
-            context.pop();
-          }
-        }
-
-        if (canRequestAds(ref.read(isSubscribeProvider)) &&
-            adInterstitial.registerPostDetailCloseAndShouldShow()) {
-          await adInterstitial.ensureAdReady(resetAttempts: true);
-          await adInterstitial.showAd(onAdClosed: popDetail);
-        } else {
-          popDetail();
-        }
-      } finally {
-        isClosing.value = false;
+      // 準備済みの広告があるときだけ表示する。未準備ならこの回は諦め、
+      // 表示権は次に閉じたときへ持ち越される。
+      final showAdOnClose = canRequestAds(ref.read(isSubscribeProvider)) &&
+          adInterstitial.registerPostDetailCloseAndShouldShow();
+      context.pop();
+      if (showAdOnClose) {
+        unawaited(adInterstitial.showAd());
       }
     }
 
@@ -119,7 +116,7 @@ class PostDetailScreen extends HookConsumerWidget {
         if (didPop || !canClose) {
           return;
         }
-        unawaited(closeDetail());
+        closeDetail();
       },
       child: Scaffold(
         appBar: AppBar(


### PR DESCRIPTION
## Issue

- close #1232

## 概要

- 投稿詳細を閉じる時に広告のロード待ちで固まらないようにしました

## 追加したPackage

- なし

## Screenshot


https://github.com/user-attachments/assets/fcc8bd34-4c4f-4576-b722-8c6c74585d35



## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Interstitial ads are now preloaded while viewing post details when available.
  * Closing a post detail screen happens immediately, without waiting for an ad to load or finish.
  * Prepared ads may be shown after closing, while unavailable or cooldown-blocked ads are deferred automatically.
  * Ad availability now responds more reliably when subscription status changes.
  * Ad resources are reset appropriately when no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->