### PR TITLE
マップ画面で検索バーが出ている状態でどこかをタップするとキーボードを閉じれるようにしました

### DIFF
--- a/lib/ui/component/app_text_field.dart
+++ b/lib/ui/component/app_text_field.dart
@@ -100,6 +100,7 @@ class AppSearchTextField extends HookWidget {
                 autocorrect: true,
                 textCapitalization: TextCapitalization.words,
                 controller: controller,
+                onTapOutside: (_) => primaryFocus?.unfocus(),
                 onSubmitted: (_) {
                   onSubmitted?.call(controller.text);
                 },

--- a/lib/ui/screen/map/map_screen.dart
+++ b/lib/ui/screen/map/map_screen.dart
@@ -106,6 +106,7 @@ class MapScreen extends HookConsumerWidget {
                     await controller.setMapController(
                       mapLibre,
                       onPinTap: (posts) async {
+                        primaryFocus?.unfocus();
                         if (posts.isEmpty || isHandlingPinTap.value) {
                           return;
                         }
@@ -153,6 +154,7 @@ class MapScreen extends HookConsumerWidget {
                     }
                   },
                   onStyleLoadedCallback: controller.onStyleLoaded,
+                  onMapClick: (_, __) => primaryFocus?.unfocus(),
                   onCameraIdle: controller.scheduleUpdateAfterCameraIdle,
                   onCameraMove: controller.onCameraMove,
                   annotationOrder: const [AnnotationType.symbol],


### PR DESCRIPTION
## Issue

- close #1244 

## 概要

- マップ画面で検索バーが出ている状態でどこかをタップするとキーボードを閉じれるようにしました

## 追加したPackage

- なし

## Screenshot


https://github.com/user-attachments/assets/7c3cd7f3-5faa-4139-a329-5da37d256b1e



## 備考

